### PR TITLE
lockstep: add backwards compat for older glib versions

### DIFF
--- a/contrib/plugins/lockstep.c
+++ b/contrib/plugins/lockstep.c
@@ -129,8 +129,13 @@ static void report_divergance(ExecState *us, ExecState *them)
             diverged = true;
         }
     }
+#if !(GLIB_CHECK_VERSION(2, 67, 3))
+    divergence_log = g_slist_prepend(divergence_log,
+                                     g_memdup(&divrec, sizeof(divrec)));
+#else
     divergence_log = g_slist_prepend(divergence_log,
                                      g_memdup2(&divrec, sizeof(divrec)));
+#endif
 
     /* Output short log entry of going out of sync... */
     if (verbose || divrec.distance == 1 || diverged) {


### PR DESCRIPTION
The g_memdup2 symbol was only added in glib-2.68. Add support for building with older versions of glib, like the one found in CentOS 7.