### PR TITLE
Share a portion of LLC with the Vulcano model

### DIFF
--- a/hw/misc/Kconfig
+++ b/hw/misc/Kconfig
@@ -203,4 +203,7 @@ config XLNX_VERSAL_TRNG
 config VUL_CSR
     bool
 
+config VUL_MEM
+    bool
+
 source macio/Kconfig

--- a/hw/misc/meson.build
+++ b/hw/misc/meson.build
@@ -155,7 +155,4 @@ system_ss.add(when: 'CONFIG_SBSA_REF', if_true: files('sbsa_ec.c'))
 # HPPA devices
 system_ss.add(when: 'CONFIG_LASI', if_true: files('lasi.c'))
 
-if config_target.get('CONFIG_VUL_CSR', 'n') == 'y'
-    specific_ss.add(files('vul_csr.c'))
-    specific_ss.add(dependency('libzmq'))
-endif
+specific_ss.add(when: 'CONFIG_VUL_CSR', if_true: files('vul_csr.c'))

--- a/hw/misc/meson.build
+++ b/hw/misc/meson.build
@@ -156,3 +156,4 @@ system_ss.add(when: 'CONFIG_SBSA_REF', if_true: files('sbsa_ec.c'))
 system_ss.add(when: 'CONFIG_LASI', if_true: files('lasi.c'))
 
 specific_ss.add(when: 'CONFIG_VUL_CSR', if_true: files('vul_csr.c'))
+specific_ss.add(when: 'CONFIG_VUL_MEM', if_true: files('vul_mem.c'))

--- a/hw/misc/vul_csr.c
+++ b/hw/misc/vul_csr.c
@@ -1,140 +1,21 @@
-#include <zmq.h>
-
 #include "qemu/osdep.h"
 #include "qapi/error.h"
 
 #include "hw/misc/vul_csr.h"
-
-/* The vul_model_* types _MUST_ be kept in sync with the model */
-typedef enum vul_model_msg_opcode_e {
-    VUL_MODEL_MSG_OPCODE_STEP_PKT = 0,
-    VUL_MODEL_MSG_OPCODE_GET_NEXT_PKT = 1,
-    VUL_MODEL_MSG_OPCODE_REG_READ = 2,
-    VUL_MODEL_MSG_OPCODE_REG_WRITE = 3,
-    VUL_MODEL_MSG_OPCODE_MEM_READ = 4,
-    VUL_MODEL_MSG_OPCODE_MEM_WRITE = 5,
-    VUL_MODEL_MSG_OPCODE_DOORBELL = 6,
-    VUL_MODEL_MSG_OPCODE_STATUS = 7,
-    VUL_MODEL_MSG_OPCODE_HBM_DUMP = 8,
-    VUL_MODEL_MSG_OPCODE_STEP_CPU_PKT = 9,
-    VUL_MODEL_MSG_OPCODE_GET_NEXT_CPU_PKT = 10,
-    VUL_MODEL_MSG_OPCODE_STEP_TIMER_WHEEL = 11,
-    VUL_MODEL_MSG_OPCODE_MAC_CFG = 12,
-    VUL_MODEL_MSG_OPCODE_MAC_EN = 13,
-    VUL_MODEL_MSG_OPCODE_MAC_SOFT_RESET = 14,
-    VUL_MODEL_MSG_OPCODE_MAC_STATS_RESET = 15,
-    VUL_MODEL_MSG_OPCODE_MAC_INTR_EN = 16,
-    VUL_MODEL_MSG_OPCODE_MAC_INTR_CLR = 17,
-    VUL_MODEL_MSG_OPCODE_REGISTER_MEM_ADDR = 18,
-    VUL_MODEL_MSG_OPCODE_EXIT_SIM = 19,
-    VUL_MODEL_MSG_OPCODE_CONFIG_DONE = 20,
-    VUL_MODEL_MSG_OPCODE_TESTCASE_BEGIN = 21,
-    VUL_MODEL_MSG_OPCODE_TESTCASE_END = 22,
-    VUL_MODEL_MSG_OPCODE_EOS_IGNORE_ADDR = 23,
-    VUL_MODEL_MSG_OPCODE_MEM_WRITE_PCIE = 24,
-    VUL_MODEL_MSG_OPCODE_MEM_RESET = 25,
-    VUL_MODEL_MSG_OPCODE_SET_LOG_LEVEL = 26,
-    VUL_MODEL_MSG_OPCODE_SET_TIME = 27,
-    VUL_MODEL_MSG_OPCODE_GET_TIME = 28,
-} vul_model_msg_opcode_t;
-
-typedef struct vul_model_port_s {
-    uint32_t    speed;      // port speed to configure
-    uint32_t    val;        // used for reset/enable
-    uint32_t    num_lanes;  // number of lanes for this port
-} vul_model_port_t;
-
-typedef struct vul_model_msg_s {
-    vul_model_msg_opcode_t type;
-    union {
-        int         size;
-        int         tcid;
-        int         log_level;
-    };
-    union {
-        int         port;   // also used for mac port num
-        int         loopid;
-        uint32_t    entry_size;
-        int         log_mpu;
-    };
-    int         cos;
-    int         status;
-    uint32_t    slowfast;
-    uint32_t    ctime;
-    uint32_t    pad;
-    uint64_t    addr;
-    uint8_t     data[0];    // custom data
-} vul_model_msg_t;
-
-static uint64_t vul_csr_read_32b(VulCSRState *s, hwaddr addr)
-{
-    vul_model_msg_t *msg = (vul_model_msg_t *)s->msg_buf;
-
-    memset(msg, 0, sizeof(vul_model_msg_t) + sizeof(uint64_t));
-    *msg = (vul_model_msg_t) {
-        .type = VUL_MODEL_MSG_OPCODE_REG_READ,
-        .addr = s->base_addr + addr,
-        .size = sizeof(uint32_t),
-    };
-
-    int rc = zmq_send(s->zmq_socket, msg, sizeof(vul_model_msg_t), 0);
-    if (rc < 0) {
-        fprintf(stderr, "Error while sending CSR read request\n");
-        exit(1);
-    }
-
-    rc = zmq_recv(s->zmq_socket, s->msg_buf, sizeof(s->msg_buf), 0);
-    if (rc < 0) {
-        fprintf(stderr, "Error while receiving CSR read response\n");
-        exit(1);
-    }
-
-    uint32_t reg_read;
-    memcpy(&reg_read, msg->data, sizeof(uint32_t));
-    return reg_read;
-}
-
-static void vul_csr_write_32b(VulCSRState *s, hwaddr addr, uint32_t data)
-{
-    vul_model_msg_t *msg = (vul_model_msg_t *)s->msg_buf;
-
-    memset(msg, 0, sizeof(vul_model_msg_t) + sizeof(uint64_t));
-    *msg = (vul_model_msg_t) {
-        .type = VUL_MODEL_MSG_OPCODE_REG_WRITE,
-        .addr = s->base_addr + addr,
-        .size = sizeof(uint32_t),
-        .entry_size = (1 << 16) | 1, /* Magic bits to implement a 32b write. See model's code for mode details */
-    };
-
-    memcpy(msg->data, &data, sizeof(data));
-
-    int rc = zmq_send(s->zmq_socket, msg, sizeof(vul_model_msg_t) + sizeof(uint32_t), 0);
-    if (rc < 0) {
-        fprintf(stderr, "Error while sending CSR write request\n");
-        exit(1);
-    }
-
-    rc = zmq_recv(s->zmq_socket, s->msg_buf, sizeof(s->msg_buf), 0);
-    if (rc < 0) {
-        fprintf(stderr, "Error while receiving CSR write response\n");
-        exit(1);
-    }
-}
+#include "vul_zmq.h"
 
 static uint64_t vul_csr_read(void *opaque, hwaddr addr, unsigned int size)
 {
     VulCSRState *s = (VulCSRState *)opaque;
 
-    assert(s->zmq_context);
-    assert(s->zmq_socket);
     assert(size <= sizeof(uint64_t));
 
     /* The vulcano model seems to operate with the assumption that only 32b accesses can happen. If the CPU happens to
      * access a 64b register in one go, let's break the read in two messages */
     uint32_t lo_data, hi_data = 0;
-    lo_data = vul_csr_read_32b(s, addr);
+    lo_data = vul_zmq_read_csr(s->base_addr + addr);
     if (size > sizeof(uint32_t)) {
-        hi_data = vul_csr_read_32b(s, addr + sizeof(uint32_t));
+        hi_data = vul_zmq_read_csr(s->base_addr + addr + sizeof(uint32_t));
     }
 
     return ((uint64_t)hi_data << 32) | lo_data;
@@ -144,16 +25,14 @@ static void vul_csr_write(void *opaque, hwaddr addr, uint64_t data, unsigned int
 {
     VulCSRState *s = (VulCSRState *)opaque;
 
-    assert(s->zmq_context);
-    assert(s->zmq_socket);
     assert(size <= sizeof(uint64_t));
 
     /* The size limitations present in the read are not present in the write, however reading multiple words in one
      * go has a quite tricky protocol and, anyway, the model still handles writes 32b at the time. Make our life simpler
      * by defaulting to a solution similar to the read */
-    vul_csr_write_32b(s, addr, data & 0xffffffff);
+    vul_zmq_write_csr(s->base_addr + addr, data & 0xffffffff);
     if (size > sizeof(uint32_t)) {
-        vul_csr_write_32b(s, addr + sizeof(uint32_t), data >> 32);
+        vul_zmq_write_csr(s->base_addr + addr + sizeof(uint32_t), data >> 32);
     }
 }
 
@@ -175,77 +54,12 @@ static const MemoryRegionOps vul_csr_ops = {
     .valid.max_access_size = 8,
 };
 
-static inline void zmq_endpoint(char *endpoint, size_t len)
-{
-    const char *user_str = getenv("ZMQ_SOC_DIR");
-    char *model_socket_name = NULL;
-    char *model_server_ip = NULL;
-
-    if (getenv("MODEL_ZMQ_TYPE_TCP")) {
-        model_socket_name = getenv("MODEL_ZMQ_TCP_PORT");
-        if (model_socket_name == NULL) {
-            model_socket_name = (char *) "50055";
-        }
-
-        model_server_ip = getenv("MODEL_ZMQ_SERVER_IP");
-        if (model_server_ip == NULL) {
-            model_server_ip = (char *) "0.0.0.0";
-        }
-
-        snprintf(endpoint, len, "tcp://%s:%s", model_server_ip, model_socket_name);
-    } else {
-        model_socket_name = getenv("MODEL_SOCKET_NAME");
-        if (model_socket_name == NULL) {
-            model_socket_name = (char *)"zmqsock";
-        }
-
-        snprintf(endpoint, len, "ipc:///%s/%s", user_str, model_socket_name);
-    }
-}
-
-static void connect_to_model(VulCSRState *s)
-{
-    char endpoint[256];
-
-    s->zmq_context = zmq_ctx_new();
-    if (!s->zmq_context) {
-        fprintf(stderr, "Couldn't create the ZMQ context\n");
-        exit(1);
-    }
-
-    s->zmq_socket = zmq_socket(s->zmq_context, ZMQ_REQ);
-    if (!s->zmq_socket) {
-        fprintf(stderr, "Couldn't create the ZMQ socket\n");
-        exit(1);
-    }
-
-    zmq_endpoint(endpoint, sizeof(endpoint));
-    if (zmq_connect(s->zmq_socket, endpoint) != 0) {
-        fprintf(stderr, "ZMQ connection failed\n");
-        exit(1);
-    }
-}
-
 static void vul_csr_realize(DeviceState *dev, Error **errp)
 {
     VulCSRState *s = VUL_CSR(dev);
 
-    connect_to_model(s);
     memory_region_init_io(&s->mmio, OBJECT(dev), &vul_csr_ops, s, TYPE_VUL_CSR, VUL_CSR_SIZE);
     sysbus_init_mmio(SYS_BUS_DEVICE(OBJECT(dev)), &s->mmio);
-}
-
-static void vul_csr_unrealize(DeviceState *dev)
-{
-    VulCSRState *s = VUL_CSR(dev);
-
-    if (s->zmq_socket) {
-        zmq_close(s->zmq_socket);
-    }
-
-    if (s->zmq_context) {
-        zmq_ctx_destroy(s->zmq_context);
-    }
 }
 
 static void vul_csr_class_init(ObjectClass *klass, void *data)
@@ -253,7 +67,6 @@ static void vul_csr_class_init(ObjectClass *klass, void *data)
     DeviceClass *dc = DEVICE_CLASS(klass);
 
     dc->realize = vul_csr_realize;
-    dc->unrealize = vul_csr_unrealize;
 }
 
 static const TypeInfo vul_csr_info = {

--- a/hw/misc/vul_mem.c
+++ b/hw/misc/vul_mem.c
@@ -1,0 +1,74 @@
+#include "qemu/osdep.h"
+#include "qapi/error.h"
+
+#include "hw/misc/vul_mem.h"
+#include "vul_zmq.h"
+
+static uint64_t vul_mem_read(void *opaque, hwaddr addr, unsigned int size)
+{
+    VulMemState *s = (VulMemState *)opaque;
+
+    assert(size <= sizeof(uint64_t));
+
+    uint64_t data;
+    vul_zmq_read_mem(s->base_addr + addr, (uint8_t *)&data, size);
+
+    return data;
+}
+
+static void vul_mem_write(void *opaque, hwaddr addr, uint64_t data, unsigned int size)
+{
+    VulMemState *s = (VulMemState *)opaque;
+
+    assert(size <= sizeof(uint64_t));
+
+    vul_zmq_write_mem(s->base_addr + addr, (uint8_t *)&data, size);
+}
+
+DeviceState *vul_mem_create(hwaddr addr, size_t region_size)
+{
+    DeviceState *dev = qdev_new(TYPE_VUL_MEM);
+    VulMemState *s = VUL_MEM(dev);
+    s->base_addr = addr;
+    s->region_size = region_size;
+    sysbus_realize_and_unref(SYS_BUS_DEVICE(dev), &error_fatal);
+    sysbus_mmio_map(SYS_BUS_DEVICE(dev), 0, addr);
+    return dev;
+}
+
+static const MemoryRegionOps vul_mem_ops = {
+    .read = vul_mem_read,
+    .write = vul_mem_write,
+    .endianness = DEVICE_NATIVE_ENDIAN,
+    .valid.min_access_size = 1,
+    .valid.max_access_size = 0, /* don't limit max size */
+};
+
+static void vul_mem_realize(DeviceState *dev, Error **errp)
+{
+    VulMemState *s = VUL_MEM(dev);
+
+    memory_region_init_io(&s->mmio, OBJECT(dev), &vul_mem_ops, s, TYPE_VUL_MEM, s->region_size);
+    sysbus_init_mmio(SYS_BUS_DEVICE(OBJECT(dev)), &s->mmio);
+}
+
+static void vul_mem_class_init(ObjectClass *klass, void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+
+    dc->realize = vul_mem_realize;
+}
+
+static const TypeInfo vul_mem_info = {
+    .name = TYPE_VUL_MEM,
+    .parent = TYPE_SYS_BUS_DEVICE,
+    .class_init = vul_mem_class_init,
+    .instance_size = sizeof(VulMemState),
+};
+
+static void vul_mem_register_types(void)
+{
+    type_register_static(&vul_mem_info);
+}
+
+type_init(vul_mem_register_types)

--- a/hw/riscv/Kconfig
+++ b/hw/riscv/Kconfig
@@ -68,6 +68,7 @@ config VUL_MODEL
     select PLATFORM_BUS
     select ACPI
     select VUL_CSR
+    select VUL_MEM
 
 config SHAKTI_C
     bool

--- a/hw/riscv/vul_model.c
+++ b/hw/riscv/vul_model.c
@@ -50,6 +50,7 @@
 #include "hw/acpi/aml-build.h"
 #include "qapi/qapi-visit-common.h"
 #include "hw/misc/vul_csr.h"
+#include "vul_zmq.h"
 
 /*
  * The vul_model_ machine physical address space used by some of the devices
@@ -912,6 +913,7 @@ static void vul_model_machine_init(MachineState *machine)
         create_fdt(s, memmap);
     }
 
+    vul_zmq_init();
     s->vul_csr = vul_csr_create(memmap[VUL_MODEL_CSRS].base);
 
     s->machine_done.notify = vul_model_machine_done;

--- a/hw/riscv/vul_model.c
+++ b/hw/riscv/vul_model.c
@@ -50,6 +50,7 @@
 #include "hw/acpi/aml-build.h"
 #include "qapi/qapi-visit-common.h"
 #include "hw/misc/vul_csr.h"
+#include "hw/misc/vul_mem.h"
 #include "vul_zmq.h"
 
 /*
@@ -81,6 +82,7 @@ static bool vul_model_use_kvm_aia(RISCVVulModelState *s)
 static const MemMapEntry vul_model_memmap[] = {
     [VUL_MODEL_MROM] =         {      0x1000,       0xf000 }, /* not really in our model, but QEMU wants it for booting */
     [VUL_MODEL_UART0] =        {     0xf0000,        0x100 },
+    [VUL_MODEL_SRAM] =         {    0x400000,      0x80000 },
     [VUL_MODEL_CSRS] =         {  0x10000000, VUL_CSR_SIZE },
     [VUL_MODEL_APLIC_M] =      {  0x78604000,       0x4000 },
     [VUL_MODEL_APLIC_S] =      {  0x78608000,       0x4000 },
@@ -169,6 +171,15 @@ static void create_fdt_socket_memory(RISCVVulModelState *s,
     char *mem_name;
     uint64_t addr, size;
     MachineState *ms = MACHINE(s);
+
+    addr = memmap[VUL_MODEL_SRAM].base + riscv_socket_mem_offset(ms, socket);
+    size = riscv_socket_mem_size(ms, socket);
+    mem_name = g_strdup_printf("/memory@%lx", (long)addr);
+    qemu_fdt_add_subnode(ms->fdt, mem_name);
+    qemu_fdt_setprop_cells(ms->fdt, mem_name, "reg",
+                           addr >> 32, addr, size >> 32, size);
+    qemu_fdt_setprop_string(ms->fdt, mem_name, "device_type", "memory");
+    riscv_socket_fdt_write_id(ms, mem_name, socket);
 
     addr = memmap[VUL_MODEL_DRAM].base + riscv_socket_mem_offset(ms, socket);
     size = riscv_socket_mem_size(ms, socket);
@@ -726,11 +737,17 @@ static void vul_model_machine_done(Notifier *notifier, void *data)
                                          machine_done);
     const MemMapEntry *memmap = vul_model_memmap;
     MachineState *machine = MACHINE(s);
-    target_ulong start_addr = memmap[VUL_MODEL_DRAM].base;
+    target_ulong start_addr;
     target_ulong firmware_end_addr, kernel_start_addr;
     const char *firmware_name = riscv_default_firmware_name(&s->soc[0]);
     uint64_t fdt_load_addr;
     uint64_t kernel_entry = 0;
+
+    if (s->use_ssram) {
+        start_addr = memmap[VUL_MODEL_SRAM].base;
+    } else {
+        start_addr = memmap[VUL_MODEL_DRAM].base + s->nicram_size;
+    }
 
     /*
      * An user provided dtb must include everything, including
@@ -767,8 +784,8 @@ static void vul_model_machine_done(Notifier *notifier, void *data)
                                          kernel_start_addr, true, NULL);
     }
 
-    fdt_load_addr = riscv_compute_fdt_addr(memmap[VUL_MODEL_DRAM].base,
-                                           memmap[VUL_MODEL_DRAM].size,
+    fdt_load_addr = riscv_compute_fdt_addr(memmap[VUL_MODEL_DRAM].base + s->nicram_size,
+                                           memmap[VUL_MODEL_DRAM].size - s->nicram_size,
                                            machine);
     riscv_load_fdt(fdt_load_addr, machine->fdt);
 
@@ -787,6 +804,7 @@ static void vul_model_machine_init(MachineState *machine)
     RISCVVulModelState *s = RISCV_VUL_MODEL_MACHINE(machine);
     MemoryRegion *system_memory = get_system_memory();
     MemoryRegion *mask_rom = g_new(MemoryRegion, 1);
+    MemoryRegion *llc = g_new(MemoryRegion, 1);
     char *soc_name;
     DeviceState *mmio_irqchip;
     int i, base_hartid, hart_count;
@@ -871,7 +889,7 @@ static void vul_model_machine_init(MachineState *machine)
 
     /* Check that the amount of RAM the user asked is the one we expect (otherwise our memory map may not make much
      * sense) */
-    assert(machine->ram_size <= memmap[VUL_MODEL_DRAM].size);
+    assert(machine->ram_size == memmap[VUL_MODEL_SRAM].size);
 
     if (riscv_is_32bit(&s->soc[0])) {
 #if HOST_LONG_BITS == 64
@@ -885,15 +903,29 @@ static void vul_model_machine_init(MachineState *machine)
 
     s->memmap = vul_model_memmap;
 
-    /* register system main memory (actual RAM) */
-    memory_region_add_subregion(system_memory, memmap[VUL_MODEL_DRAM].base,
-        machine->ram);
+    /* register SRAM boot memory */
+    memory_region_add_subregion(system_memory, memmap[VUL_MODEL_SRAM].base,
+                            machine->ram);
 
     /* boot rom */
     memory_region_init_rom(mask_rom, NULL, "riscv_vul_model_board.mrom",
                            memmap[VUL_MODEL_MROM].size, &error_fatal);
     memory_region_add_subregion(system_memory, memmap[VUL_MODEL_MROM].base,
                                 mask_rom);
+
+    vul_zmq_init();
+
+    /* Register QEMU-backed RAM. The real LLC region where FW executes in real HW is 32 MiB big. For modeling purposes,
+     * we need to partition such memory between QEMU's own RAM (to execute Zephyr and store Zephyr dedicated data) and
+     * the model's RAM (which is hosted by the model and has a much higher accessing cost, but it's where things like
+     * config space and data to DMA needs to live). */
+    memory_region_init_ram(llc, NULL, "riscv_vul_model_board.llc",
+                           memmap[VUL_MODEL_DRAM].size - s->nicram_size, &error_fatal);
+    memory_region_add_subregion(system_memory,
+                                memmap[VUL_MODEL_DRAM].base + s->nicram_size,
+                                llc);
+    s->vul_mem = vul_mem_create(memmap[VUL_MODEL_DRAM].base, s->nicram_size);
+    s->vul_csr = vul_csr_create(memmap[VUL_MODEL_CSRS].base);
 
     /* SiFive Test MMIO device */
     sifive_test_create(memmap[VUL_MODEL_TEST].base);
@@ -912,9 +944,6 @@ static void vul_model_machine_init(MachineState *machine)
     } else {
         create_fdt(s, memmap);
     }
-
-    vul_zmq_init();
-    s->vul_csr = vul_csr_create(memmap[VUL_MODEL_CSRS].base);
 
     s->machine_done.notify = vul_model_machine_done;
     qemu_add_machine_init_done_notifier(&s->machine_done);
@@ -940,6 +969,62 @@ static HotplugHandler *vul_model_machine_get_hotplug_handler(MachineState *machi
     return NULL;
 }
 
+static bool vul_model_get_ssram(Object *obj, Error **errp)
+{
+    RISCVVulModelState *s = RISCV_VUL_MODEL_MACHINE(obj);
+
+    return s->use_ssram;
+}
+
+static void vul_model_set_ssram(Object *obj, bool value, Error **errp)
+{
+    RISCVVulModelState *s = RISCV_VUL_MODEL_MACHINE(obj);
+
+    s->use_ssram = value;
+}
+
+static char *vul_model_get_nicram(Object *obj, Error **errp)
+{
+    RISCVVulModelState *s = RISCV_VUL_MODEL_MACHINE(obj);
+    char val[32];
+
+    sprintf(val, "%zu B\n", s->nicram_size);
+
+    return g_strdup(val);
+}
+
+static void vul_model_set_nicram(Object *obj, const char *val, Error **errp)
+{
+    RISCVVulModelState *s = RISCV_VUL_MODEL_MACHINE(obj);
+
+    char unit;
+    size_t base_val;
+    int rc = sscanf(val, "%zu%c", &base_val, &unit);
+    if (rc != 2) {
+        goto nicram_err;
+    }
+
+    switch (unit) {
+        case 'b':
+            s->nicram_size = base_val;
+            break;
+        case 'k':
+            s->nicram_size = base_val * 1024;
+            break;
+        case 'M':
+            s->nicram_size = base_val * 1024 * 1024;
+            break;
+        default:
+            goto nicram_err;
+    }
+
+    return;
+
+nicram_err:
+    error_setg(errp, "Invalid NIC RAM memory size");
+    error_append_hint(errp, "Valid format is <size><b|k|M>.\n");
+}
+
 static void vul_model_machine_class_init(ObjectClass *oc, void *data)
 {
     MachineClass *mc = MACHINE_CLASS(oc);
@@ -963,6 +1048,16 @@ static void vul_model_machine_class_init(ObjectClass *oc, void *data)
 #ifdef CONFIG_TPM
     machine_class_allow_dynamic_sysbus_dev(mc, TYPE_TPM_TIS_SYSBUS);
 #endif
+
+    object_class_property_add_bool(oc, "ssram", vul_model_get_ssram,
+                                   vul_model_set_ssram);
+    object_class_property_set_description(oc, "ssram",
+                                          "Use an SSRAM to boot from, rather than starting directly from LLC");
+
+    object_class_property_add_str(oc, "nicram", vul_model_get_nicram,
+                                  vul_model_set_nicram);
+    object_class_property_set_description(oc, "nicram",
+                                          "The size of the memory portion to redirect into NIC RAM.");
 }
 
 static const TypeInfo vul_model_machine_typeinfo = {

--- a/hw/riscv/vul_model.c
+++ b/hw/riscv/vul_model.c
@@ -39,17 +39,13 @@
 #include "hw/intc/riscv_aclint.h"
 #include "hw/intc/riscv_aplic.h"
 #include "hw/intc/riscv_imsic.h"
-#include "hw/intc/sifive_plic.h"
 #include "hw/misc/sifive_test.h"
-#include "hw/platform-bus.h"
 #include "chardev/char.h"
 #include "sysemu/device_tree.h"
 #include "sysemu/sysemu.h"
 #include "sysemu/tcg.h"
 #include "sysemu/kvm.h"
 #include "sysemu/tpm.h"
-#include "hw/pci/pci.h"
-#include "hw/pci-host/gpex.h"
 #include "hw/display/ramfb.h"
 #include "hw/acpi/aml-build.h"
 #include "qapi/qapi-visit-common.h"
@@ -79,15 +75,12 @@ static bool vul_model_use_kvm_aia(RISCVVulModelState *s)
     return kvm_irqchip_in_kernel() && s->aia_type == VUL_MODEL_AIA_TYPE_APLIC_IMSIC;
 }
 
-#define VUL_MODEL_FLASH_SECTOR_SIZE (64 * KiB)
 #define VUL_MODEL_UART0_REG_SHIFT 2
 
 static const MemMapEntry vul_model_memmap[] = {
-    /* Stuff we actually care about in the model */
     [VUL_MODEL_MROM] =         {      0x1000,       0xf000 }, /* not really in our model, but QEMU wants it for booting */
     [VUL_MODEL_UART0] =        {     0xf0000,        0x100 },
     [VUL_MODEL_CSRS] =         {  0x10000000, VUL_CSR_SIZE },
-    [VUL_MODEL_PLIC] =         {  0x78600000,       0x8000 }, /* not relevant */
     [VUL_MODEL_APLIC_M] =      {  0x78604000,       0x4000 },
     [VUL_MODEL_APLIC_S] =      {  0x78608000,       0x4000 },
     [VUL_MODEL_IMSIC_M] =      {  0x78900000,       0x4000 },
@@ -96,144 +89,7 @@ static const MemMapEntry vul_model_memmap[] = {
     [VUL_MODEL_DEBUG] =        {  0x7e000000,       0x1000 },
     [VUL_MODEL_TEST] =         {  0x7e004000,       0x1000 },
     [VUL_MODEL_DRAM] =         {  0x80000000,    0x2000000 },
-    /* There are things we don't care about that are present in the virt model, on which this board is based upon,
-     * and aren't meaningfully mentioned in the HAPS DTS.
-     * Ideally we'd remove anything we don't use, however for some of the entries that requires additional work to make
-     * sure the rest of the model works and doesn't present a tangible benefit for our current use case.
-     * As such, we move these things outside of any memory range we may use. Currently, a good place where to move all
-     * of this stuff is the address region from which LLC should be accessed in SRAM mode. */
-    [VUL_MODEL_FLASH] =        { 0x200000000,     2 * VUL_MODEL_FLASH_SECTOR_SIZE },
-    [VUL_MODEL_RTC] =          { 0x200020000,        0x10000 },
-    [VUL_MODEL_ACLINT_SSWI] =  { 0x200021000,        0x1000 },
-    [VUL_MODEL_PCIE_PIO] =     { 0x200022000,       0x1000 },
-    [VUL_MODEL_PLATFORM_BUS] = { 0x200023000,     0x1000 },
-    [VUL_MODEL_VIRTIO] =       { 0x200024000,        0x1000 },
-    [VUL_MODEL_FW_CFG] =       { 0x200025000,          0x18 },
-    [VUL_MODEL_PCIE_ECAM] =    { 0x200026000,    0x1000 },
-    [VUL_MODEL_PCIE_MMIO] =    { 0x200027000,    0x1000 },
 };
-
-/* PCIe high mmio is fixed for RV32 */
-#define VIRT32_HIGH_PCIE_MMIO_BASE  0x300000000ULL
-#define VIRT32_HIGH_PCIE_MMIO_SIZE  (4 * GiB)
-
-/* PCIe high mmio for RV64, size is fixed but base depends on top of RAM */
-#define VIRT64_HIGH_PCIE_MMIO_SIZE  (16 * GiB)
-
-static MemMapEntry vul_model_high_pcie_memmap;
-
-static PFlashCFI01 *vul_model_flash_create1(RISCVVulModelState *s,
-                                       const char *name,
-                                       const char *alias_prop_name)
-{
-    /*
-     * Create a single flash device.  We use the same parameters as
-     * the flash devices on the ARM vul_model_ board.
-     */
-    DeviceState *dev = qdev_new(TYPE_PFLASH_CFI01);
-
-    qdev_prop_set_uint64(dev, "sector-length", VUL_MODEL_FLASH_SECTOR_SIZE);
-    qdev_prop_set_uint8(dev, "width", 4);
-    qdev_prop_set_uint8(dev, "device-width", 2);
-    qdev_prop_set_bit(dev, "big-endian", false);
-    qdev_prop_set_uint16(dev, "id0", 0x89);
-    qdev_prop_set_uint16(dev, "id1", 0x18);
-    qdev_prop_set_uint16(dev, "id2", 0x00);
-    qdev_prop_set_uint16(dev, "id3", 0x00);
-    qdev_prop_set_string(dev, "name", name);
-
-    object_property_add_child(OBJECT(s), name, OBJECT(dev));
-    object_property_add_alias(OBJECT(s), alias_prop_name,
-                              OBJECT(dev), "drive");
-
-    return PFLASH_CFI01(dev);
-}
-
-static void vul_model_flash_create(RISCVVulModelState *s)
-{
-    s->flash[0] = vul_model_flash_create1(s, "vul_model_.flash0", "pflash0");
-    s->flash[1] = vul_model_flash_create1(s, "vul_model_.flash1", "pflash1");
-}
-
-static void vul_model_flash_map1(PFlashCFI01 *flash,
-                            hwaddr base, hwaddr size,
-                            MemoryRegion *sysmem)
-{
-    DeviceState *dev = DEVICE(flash);
-
-    assert(QEMU_IS_ALIGNED(size, VUL_MODEL_FLASH_SECTOR_SIZE));
-    assert(size / VUL_MODEL_FLASH_SECTOR_SIZE <= UINT32_MAX);
-    qdev_prop_set_uint32(dev, "num-blocks", size / VUL_MODEL_FLASH_SECTOR_SIZE);
-    sysbus_realize_and_unref(SYS_BUS_DEVICE(dev), &error_fatal);
-
-    memory_region_add_subregion(sysmem, base,
-                                sysbus_mmio_get_region(SYS_BUS_DEVICE(dev),
-                                                       0));
-}
-
-static void vul_model_flash_map(RISCVVulModelState *s,
-                           MemoryRegion *sysmem)
-{
-    hwaddr flashsize = vul_model_memmap[VUL_MODEL_FLASH].size / 2;
-    hwaddr flashbase = vul_model_memmap[VUL_MODEL_FLASH].base;
-
-    vul_model_flash_map1(s->flash[0], flashbase, flashsize,
-                    sysmem);
-    vul_model_flash_map1(s->flash[1], flashbase + flashsize, flashsize,
-                    sysmem);
-}
-
-static void create_pcie_irq_map(RISCVVulModelState *s, void *fdt, char *nodename,
-                                uint32_t irqchip_phandle)
-{
-    int pin, dev;
-    uint32_t irq_map_stride = 0;
-    uint32_t full_irq_map[GPEX_NUM_IRQS * GPEX_NUM_IRQS *
-                          FDT_MAX_INT_MAP_WIDTH] = {};
-    uint32_t *irq_map = full_irq_map;
-
-    /* This code creates a standard swizzle of interrupts such that
-     * each device's first interrupt is based on it's PCI_SLOT number.
-     * (See pci_swizzle_map_irq_fn())
-     *
-     * We only need one entry per interrupt in the table (not one per
-     * possible slot) seeing the interrupt-map-mask will allow the table
-     * to wrap to any number of devices.
-     */
-    for (dev = 0; dev < GPEX_NUM_IRQS; dev++) {
-        int devfn = dev * 0x8;
-
-        for (pin = 0; pin < GPEX_NUM_IRQS; pin++) {
-            int irq_nr = PCIE_IRQ + ((pin + PCI_SLOT(devfn)) % GPEX_NUM_IRQS);
-            int i = 0;
-
-            /* Fill PCI address cells */
-            irq_map[i] = cpu_to_be32(devfn << 8);
-            i += FDT_PCI_ADDR_CELLS;
-
-            /* Fill PCI Interrupt cells */
-            irq_map[i] = cpu_to_be32(pin + 1);
-            i += FDT_PCI_INT_CELLS;
-
-            /* Fill interrupt controller phandle and cells */
-            irq_map[i++] = cpu_to_be32(irqchip_phandle);
-            irq_map[i++] = cpu_to_be32(irq_nr);
-            irq_map[i++] = cpu_to_be32(0x4);
-
-            if (!irq_map_stride) {
-                irq_map_stride = i;
-            }
-            irq_map += irq_map_stride;
-        }
-    }
-
-    qemu_fdt_setprop(fdt, nodename, "interrupt-map", full_irq_map,
-                     GPEX_NUM_IRQS * GPEX_NUM_IRQS *
-                     irq_map_stride * sizeof(uint32_t));
-
-    qemu_fdt_setprop_cells(fdt, nodename, "interrupt-map-mask",
-                           0x1800, 0, 0, 0x7);
-}
 
 static void create_fdt_socket_cpus(RISCVVulModelState *s, int socket,
                                    char *clust_name, uint32_t *phandle,
@@ -568,7 +424,6 @@ static void create_fdt_socket_aplic(RISCVVulModelState *s,
 {
     char *aplic_name;
     unsigned long aplic_addr;
-    MachineState *ms = MACHINE(s);
     uint32_t aplic_m_phandle, aplic_s_phandle;
 
     aplic_m_phandle = (*phandle)++;
@@ -594,13 +449,6 @@ static void create_fdt_socket_aplic(RISCVVulModelState *s,
 
     aplic_name = g_strdup_printf("/soc/aplic@%lx", aplic_addr);
 
-    if (!socket) {
-        platform_bus_add_all_fdt_nodes(ms->fdt, aplic_name,
-                                       memmap[VUL_MODEL_PLATFORM_BUS].base,
-                                       memmap[VUL_MODEL_PLATFORM_BUS].size,
-                                       VIRT_PLATFORM_BUS_IRQ);
-    }
-
     g_free(aplic_name);
 
     aplic_phandles[socket] = aplic_s_phandle;
@@ -622,10 +470,7 @@ static void create_fdt_pmu(RISCVVulModelState *s)
 
 static void create_fdt_sockets(RISCVVulModelState *s, const MemMapEntry *memmap,
                                uint32_t *phandle,
-                               uint32_t *irq_mmio_phandle,
-                               uint32_t *irq_pcie_phandle,
-                               uint32_t *irq_virtio_phandle,
-                               uint32_t *msi_pcie_phandle)
+                               uint32_t *irq_mmio_phandle)
 {
     char *clust_name;
     int socket, phandle_pos;
@@ -670,7 +515,6 @@ static void create_fdt_sockets(RISCVVulModelState *s, const MemMapEntry *memmap,
 
     create_fdt_imsic(s, memmap, phandle, intc_phandles,
         &msi_m_phandle, &msi_s_phandle);
-    *msi_pcie_phandle = msi_s_phandle;
 
     /* KVM AIA only has one APLIC instance */
     if (kvm_enabled() && vul_model_use_kvm_aia(s)) {
@@ -695,88 +539,15 @@ static void create_fdt_sockets(RISCVVulModelState *s, const MemMapEntry *memmap,
 
     if (kvm_enabled() && vul_model_use_kvm_aia(s)) {
         *irq_mmio_phandle = xplic_phandles[0];
-        *irq_virtio_phandle = xplic_phandles[0];
-        *irq_pcie_phandle = xplic_phandles[0];
     } else {
         for (socket = 0; socket < socket_count; socket++) {
             if (socket == 0) {
                 *irq_mmio_phandle = xplic_phandles[socket];
-                *irq_virtio_phandle = xplic_phandles[socket];
-                *irq_pcie_phandle = xplic_phandles[socket];
-            }
-            if (socket == 1) {
-                *irq_virtio_phandle = xplic_phandles[socket];
-                *irq_pcie_phandle = xplic_phandles[socket];
-            }
-            if (socket == 2) {
-                *irq_pcie_phandle = xplic_phandles[socket];
             }
         }
     }
 
     riscv_socket_fdt_write_distance_matrix(ms);
-}
-
-static void create_fdt_virtio(RISCVVulModelState *s, const MemMapEntry *memmap,
-                              uint32_t irq_virtio_phandle)
-{
-    int i;
-    char *name;
-    MachineState *ms = MACHINE(s);
-
-    for (i = 0; i < VIRTIO_COUNT; i++) {
-        name = g_strdup_printf("/soc/virtio_mmio@%lx",
-            (long)(memmap[VUL_MODEL_VIRTIO].base + i * memmap[VUL_MODEL_VIRTIO].size));
-        qemu_fdt_add_subnode(ms->fdt, name);
-        qemu_fdt_setprop_string(ms->fdt, name, "compatible", "virtio,mmio");
-        qemu_fdt_setprop_cells(ms->fdt, name, "reg",
-            0x0, memmap[VUL_MODEL_VIRTIO].base + i * memmap[VUL_MODEL_VIRTIO].size,
-            0x0, memmap[VUL_MODEL_VIRTIO].size);
-        qemu_fdt_setprop_cell(ms->fdt, name, "interrupt-parent",
-            irq_virtio_phandle);
-        qemu_fdt_setprop_cells(ms->fdt, name, "interrupts",
-                               VIRTIO_IRQ + i, 0x4);
-        g_free(name);
-    }
-}
-
-static void create_fdt_pcie(RISCVVulModelState *s, const MemMapEntry *memmap,
-                            uint32_t irq_pcie_phandle,
-                            uint32_t msi_pcie_phandle)
-{
-    char *name;
-    MachineState *ms = MACHINE(s);
-
-    name = g_strdup_printf("/soc/pci@%lx",
-        (long) memmap[VUL_MODEL_PCIE_ECAM].base);
-    qemu_fdt_add_subnode(ms->fdt, name);
-    qemu_fdt_setprop_cell(ms->fdt, name, "#address-cells",
-        FDT_PCI_ADDR_CELLS);
-    qemu_fdt_setprop_cell(ms->fdt, name, "#interrupt-cells",
-        FDT_PCI_INT_CELLS);
-    qemu_fdt_setprop_cell(ms->fdt, name, "#size-cells", 0x2);
-    qemu_fdt_setprop_string(ms->fdt, name, "compatible",
-        "pci-host-ecam-generic");
-    qemu_fdt_setprop_string(ms->fdt, name, "device_type", "pci");
-    qemu_fdt_setprop_cell(ms->fdt, name, "linux,pci-domain", 0);
-    qemu_fdt_setprop_cells(ms->fdt, name, "bus-range", 0,
-        memmap[VUL_MODEL_PCIE_ECAM].size / PCIE_MMCFG_SIZE_MIN - 1);
-    qemu_fdt_setprop(ms->fdt, name, "dma-coherent", NULL, 0);
-    qemu_fdt_setprop_cell(ms->fdt, name, "msi-parent", msi_pcie_phandle);
-    qemu_fdt_setprop_cells(ms->fdt, name, "reg", 0,
-        memmap[VUL_MODEL_PCIE_ECAM].base, 0, memmap[VUL_MODEL_PCIE_ECAM].size);
-    qemu_fdt_setprop_sized_cells(ms->fdt, name, "ranges",
-        1, FDT_PCI_RANGE_IOPORT, 2, 0,
-        2, memmap[VUL_MODEL_PCIE_PIO].base, 2, memmap[VUL_MODEL_PCIE_PIO].size,
-        1, FDT_PCI_RANGE_MMIO,
-        2, memmap[VUL_MODEL_PCIE_MMIO].base,
-        2, memmap[VUL_MODEL_PCIE_MMIO].base, 2, memmap[VUL_MODEL_PCIE_MMIO].size,
-        1, FDT_PCI_RANGE_MMIO_64BIT,
-        2, vul_model_high_pcie_memmap.base,
-        2, vul_model_high_pcie_memmap.base, 2, vul_model_high_pcie_memmap.size);
-
-    create_pcie_irq_map(s, ms->fdt, name, irq_pcie_phandle);
-    g_free(name);
 }
 
 static void create_fdt_reset(RISCVVulModelState *s, const MemMapEntry *memmap,
@@ -841,76 +612,15 @@ static void create_fdt_uart(RISCVVulModelState *s, const MemMapEntry *memmap,
     g_free(name);
 }
 
-static void create_fdt_rtc(RISCVVulModelState *s, const MemMapEntry *memmap,
-                           uint32_t irq_mmio_phandle)
-{
-    char *name;
-    MachineState *ms = MACHINE(s);
-
-    name = g_strdup_printf("/soc/rtc@%lx", (long)memmap[VUL_MODEL_RTC].base);
-    qemu_fdt_add_subnode(ms->fdt, name);
-    qemu_fdt_setprop_string(ms->fdt, name, "compatible",
-        "google,goldfish-rtc");
-    qemu_fdt_setprop_cells(ms->fdt, name, "reg",
-        0x0, memmap[VUL_MODEL_RTC].base, 0x0, memmap[VUL_MODEL_RTC].size);
-    qemu_fdt_setprop_cell(ms->fdt, name, "interrupt-parent",
-        irq_mmio_phandle);
-    qemu_fdt_setprop_cells(ms->fdt, name, "interrupts", RTC_IRQ, 0x4);
-    g_free(name);
-}
-
-static void create_fdt_flash(RISCVVulModelState *s, const MemMapEntry *memmap)
-{
-    char *name;
-    MachineState *ms = MACHINE(s);
-    hwaddr flashsize = vul_model_memmap[VUL_MODEL_FLASH].size / 2;
-    hwaddr flashbase = vul_model_memmap[VUL_MODEL_FLASH].base;
-
-    name = g_strdup_printf("/flash@%" PRIx64, flashbase);
-    qemu_fdt_add_subnode(ms->fdt, name);
-    qemu_fdt_setprop_string(ms->fdt, name, "compatible", "cfi-flash");
-    qemu_fdt_setprop_sized_cells(ms->fdt, name, "reg",
-                                 2, flashbase, 2, flashsize,
-                                 2, flashbase + flashsize, 2, flashsize);
-    qemu_fdt_setprop_cell(ms->fdt, name, "bank-width", 4);
-    g_free(name);
-}
-
-static void create_fdt_fw_cfg(RISCVVulModelState *s, const MemMapEntry *memmap)
-{
-    char *nodename;
-    MachineState *ms = MACHINE(s);
-    hwaddr base = memmap[VUL_MODEL_FW_CFG].base;
-    hwaddr size = memmap[VUL_MODEL_FW_CFG].size;
-
-    nodename = g_strdup_printf("/fw-cfg@%" PRIx64, base);
-    qemu_fdt_add_subnode(ms->fdt, nodename);
-    qemu_fdt_setprop_string(ms->fdt, nodename,
-                            "compatible", "qemu,fw-cfg-mmio");
-    qemu_fdt_setprop_sized_cells(ms->fdt, nodename, "reg",
-                                 2, base, 2, size);
-    qemu_fdt_setprop(ms->fdt, nodename, "dma-coherent", NULL, 0);
-    g_free(nodename);
-}
-
 static void finalize_fdt(RISCVVulModelState *s)
 {
-    uint32_t phandle = 1, irq_mmio_phandle = 1, msi_pcie_phandle = 1;
-    uint32_t irq_pcie_phandle = 1, irq_virtio_phandle = 1;
+    uint32_t phandle = 1, irq_mmio_phandle = 1;
 
-    create_fdt_sockets(s, vul_model_memmap, &phandle, &irq_mmio_phandle,
-                       &irq_pcie_phandle, &irq_virtio_phandle,
-                       &msi_pcie_phandle);
-
-    create_fdt_virtio(s, vul_model_memmap, irq_virtio_phandle);
-
-    create_fdt_pcie(s, vul_model_memmap, irq_pcie_phandle, msi_pcie_phandle);
+    create_fdt_sockets(s, vul_model_memmap, &phandle, &irq_mmio_phandle);
 
     create_fdt_reset(s, vul_model_memmap, &phandle);
 
     create_fdt_uart(s, vul_model_memmap, irq_mmio_phandle);
-
-    create_fdt_rtc(s, vul_model_memmap, irq_mmio_phandle);
 }
 
 static void create_fdt(RISCVVulModelState *s, const MemMapEntry *memmap)
@@ -942,70 +652,7 @@ static void create_fdt(RISCVVulModelState *s, const MemMapEntry *memmap)
     qemu_fdt_setprop(ms->fdt, "/chosen", "rng-seed",
                      rng_seed, sizeof(rng_seed));
 
-    create_fdt_flash(s, memmap);
-    create_fdt_fw_cfg(s, memmap);
     create_fdt_pmu(s);
-}
-
-static inline DeviceState *gpex_pcie_init(MemoryRegion *sys_mem,
-                                          hwaddr ecam_base, hwaddr ecam_size,
-                                          hwaddr mmio_base, hwaddr mmio_size,
-                                          hwaddr high_mmio_base,
-                                          hwaddr high_mmio_size,
-                                          hwaddr pio_base,
-                                          DeviceState *irqchip)
-{
-    DeviceState *dev;
-    MemoryRegion *ecam_alias, *ecam_reg;
-    MemoryRegion *mmio_alias, *high_mmio_alias, *mmio_reg;
-    qemu_irq irq;
-    int i;
-
-    dev = qdev_new(TYPE_GPEX_HOST);
-
-    sysbus_realize_and_unref(SYS_BUS_DEVICE(dev), &error_fatal);
-
-    ecam_alias = g_new0(MemoryRegion, 1);
-    ecam_reg = sysbus_mmio_get_region(SYS_BUS_DEVICE(dev), 0);
-    memory_region_init_alias(ecam_alias, OBJECT(dev), "pcie-ecam",
-                             ecam_reg, 0, ecam_size);
-    memory_region_add_subregion(get_system_memory(), ecam_base, ecam_alias);
-
-    mmio_alias = g_new0(MemoryRegion, 1);
-    mmio_reg = sysbus_mmio_get_region(SYS_BUS_DEVICE(dev), 1);
-    memory_region_init_alias(mmio_alias, OBJECT(dev), "pcie-mmio",
-                             mmio_reg, mmio_base, mmio_size);
-    memory_region_add_subregion(get_system_memory(), mmio_base, mmio_alias);
-
-    /* Map high MMIO space */
-    high_mmio_alias = g_new0(MemoryRegion, 1);
-    memory_region_init_alias(high_mmio_alias, OBJECT(dev), "pcie-mmio-high",
-                             mmio_reg, high_mmio_base, high_mmio_size);
-    memory_region_add_subregion(get_system_memory(), high_mmio_base,
-                                high_mmio_alias);
-
-    sysbus_mmio_map(SYS_BUS_DEVICE(dev), 2, pio_base);
-
-    for (i = 0; i < GPEX_NUM_IRQS; i++) {
-        irq = qdev_get_gpio_in(irqchip, PCIE_IRQ + i);
-
-        sysbus_connect_irq(SYS_BUS_DEVICE(dev), i, irq);
-        gpex_set_irq_num(GPEX_HOST(dev), i, PCIE_IRQ + i);
-    }
-
-    return dev;
-}
-
-static FWCfgState *create_fw_cfg(const MachineState *ms)
-{
-    hwaddr base = vul_model_memmap[VUL_MODEL_FW_CFG].base;
-    FWCfgState *fw_cfg;
-
-    fw_cfg = fw_cfg_init_mem_wide(base + 8, base, 8, base + 16,
-                                  &address_space_memory);
-    fw_cfg_add_i16(fw_cfg, FW_CFG_NB_CPUS, (uint16_t)ms->smp.cpus);
-
-    return fw_cfg;
 }
 
 static DeviceState *vul_model_create_aia(RISCVVulModelAIAType aia_type, int aia_guests,
@@ -1072,32 +719,6 @@ static DeviceState *vul_model_create_aia(RISCVVulModelAIAType aia_type, int aia_
     return kvm_enabled() ? aplic_s : aplic_m;
 }
 
-static void create_platform_bus(RISCVVulModelState *s, DeviceState *irqchip)
-{
-    DeviceState *dev;
-    SysBusDevice *sysbus;
-    const MemMapEntry *memmap = vul_model_memmap;
-    int i;
-    MemoryRegion *sysmem = get_system_memory();
-
-    dev = qdev_new(TYPE_PLATFORM_BUS_DEVICE);
-    dev->id = g_strdup(TYPE_PLATFORM_BUS_DEVICE);
-    qdev_prop_set_uint32(dev, "num_irqs", VUL_MODEL_PLATFORM_BUS_NUM_IRQS);
-    qdev_prop_set_uint32(dev, "mmio_size", memmap[VUL_MODEL_PLATFORM_BUS].size);
-    sysbus_realize_and_unref(SYS_BUS_DEVICE(dev), &error_fatal);
-    s->platform_bus_dev = dev;
-
-    sysbus = SYS_BUS_DEVICE(dev);
-    for (i = 0; i < VUL_MODEL_PLATFORM_BUS_NUM_IRQS; i++) {
-        int irq = VIRT_PLATFORM_BUS_IRQ + i;
-        sysbus_connect_irq(sysbus, i, qdev_get_gpio_in(irqchip, irq));
-    }
-
-    memory_region_add_subregion(sysmem,
-                                memmap[VUL_MODEL_PLATFORM_BUS].base,
-                                sysbus_mmio_get_region(sysbus, 0));
-}
-
 static void vul_model_machine_done(Notifier *notifier, void *data)
 {
     RISCVVulModelState *s = container_of(notifier, RISCVVulModelState,
@@ -1109,7 +730,6 @@ static void vul_model_machine_done(Notifier *notifier, void *data)
     const char *firmware_name = riscv_default_firmware_name(&s->soc[0]);
     uint64_t fdt_load_addr;
     uint64_t kernel_entry = 0;
-    BlockBackend *pflash_blk0;
 
     /*
      * An user provided dtb must include everything, including
@@ -1137,26 +757,6 @@ static void vul_model_machine_done(Notifier *notifier, void *data)
 
     firmware_end_addr = riscv_find_and_load_firmware(machine, firmware_name,
                                                      start_addr, NULL);
-
-    pflash_blk0 = pflash_cfi01_get_blk(s->flash[0]);
-    if (pflash_blk0) {
-        if (machine->firmware && !strcmp(machine->firmware, "none") &&
-            !kvm_enabled()) {
-            /*
-             * Pflash was supplied but bios is none and not KVM guest,
-             * let's overwrite the address we jump to after reset to
-             * the base of the flash.
-             */
-            start_addr = vul_model_memmap[VUL_MODEL_FLASH].base;
-        } else {
-            /*
-             * Pflash was supplied but either KVM guest or bios is not none.
-             * In this case, base of the flash would contain S-mode payload.
-             */
-            riscv_setup_firmware_boot(machine);
-            kernel_entry = vul_model_memmap[VUL_MODEL_FLASH].base;
-        }
-    }
 
     if (machine->kernel_filename && !kernel_entry) {
         kernel_start_addr = riscv_calc_kernel_start_addr(&s->soc[0],
@@ -1187,7 +787,7 @@ static void vul_model_machine_init(MachineState *machine)
     MemoryRegion *system_memory = get_system_memory();
     MemoryRegion *mask_rom = g_new(MemoryRegion, 1);
     char *soc_name;
-    DeviceState *mmio_irqchip, *virtio_irqchip, *pcie_irqchip;
+    DeviceState *mmio_irqchip;
     int i, base_hartid, hart_count;
     int socket_count = riscv_socket_count(machine);
 
@@ -1207,7 +807,7 @@ static void vul_model_machine_init(MachineState *machine)
     }
 
     /* Initialize sockets */
-    mmio_irqchip = virtio_irqchip = pcie_irqchip = NULL;
+    mmio_irqchip = NULL;
     for (i = 0; i < socket_count; i++) {
         if (!riscv_socket_check_hartids(machine, i)) {
             error_report("discontinuous hartids in socket%d", i);
@@ -1257,15 +857,6 @@ static void vul_model_machine_init(MachineState *machine)
         /* Try to use different IRQCHIP instance based device type */
         if (i == 0) {
             mmio_irqchip = s->irqchip[i];
-            virtio_irqchip = s->irqchip[i];
-            pcie_irqchip = s->irqchip[i];
-        }
-        if (i == 1) {
-            virtio_irqchip = s->irqchip[i];
-            pcie_irqchip = s->irqchip[i];
-        }
-        if (i == 2) {
-            pcie_irqchip = s->irqchip[i];
         }
     }
 
@@ -1289,13 +880,6 @@ static void vul_model_machine_init(MachineState *machine)
             error_report("Limiting RAM size to 10 GiB");
         }
 #endif
-        vul_model_high_pcie_memmap.base = VIRT32_HIGH_PCIE_MMIO_BASE;
-        vul_model_high_pcie_memmap.size = VIRT32_HIGH_PCIE_MMIO_SIZE;
-    } else {
-        vul_model_high_pcie_memmap.size = VIRT64_HIGH_PCIE_MMIO_SIZE;
-        vul_model_high_pcie_memmap.base = memmap[VUL_MODEL_DRAM].base + machine->ram_size;
-        vul_model_high_pcie_memmap.base =
-            ROUND_UP(vul_model_high_pcie_memmap.base, vul_model_high_pcie_memmap.size);
     }
 
     s->memmap = vul_model_memmap;
@@ -1310,48 +894,12 @@ static void vul_model_machine_init(MachineState *machine)
     memory_region_add_subregion(system_memory, memmap[VUL_MODEL_MROM].base,
                                 mask_rom);
 
-    /*
-     * Init fw_cfg. Must be done before riscv_load_fdt, otherwise the
-     * device tree cannot be altered and we get FDT_ERR_NOSPACE.
-     */
-    s->fw_cfg = create_fw_cfg(machine);
-    rom_set_fw(s->fw_cfg);
-
     /* SiFive Test MMIO device */
     sifive_test_create(memmap[VUL_MODEL_TEST].base);
-
-    /* VirtIO MMIO devices */
-    for (i = 0; i < VIRTIO_COUNT; i++) {
-        sysbus_create_simple("virtio-mmio",
-            memmap[VUL_MODEL_VIRTIO].base + i * memmap[VUL_MODEL_VIRTIO].size,
-            qdev_get_gpio_in(virtio_irqchip, VIRTIO_IRQ + i));
-    }
-
-    gpex_pcie_init(system_memory,
-                   memmap[VUL_MODEL_PCIE_ECAM].base,
-                   memmap[VUL_MODEL_PCIE_ECAM].size,
-                   memmap[VUL_MODEL_PCIE_MMIO].base,
-                   memmap[VUL_MODEL_PCIE_MMIO].size,
-                   vul_model_high_pcie_memmap.base,
-                   vul_model_high_pcie_memmap.size,
-                   memmap[VUL_MODEL_PCIE_PIO].base,
-                   pcie_irqchip);
-
-    create_platform_bus(s, mmio_irqchip);
 
     serial_mm_init(system_memory, memmap[VUL_MODEL_UART0].base,
                    VUL_MODEL_UART0_REG_SHIFT, qdev_get_gpio_in(mmio_irqchip, UART0_IRQ), 399193,
                    serial_hd(0), DEVICE_LITTLE_ENDIAN);
-
-    sysbus_create_simple("goldfish_rtc", memmap[VUL_MODEL_RTC].base,
-        qdev_get_gpio_in(mmio_irqchip, RTC_IRQ));
-
-    for (i = 0; i < ARRAY_SIZE(s->flash); i++) {
-        /* Map legacy -drive if=pflash to machine properties */
-        pflash_cfi01_legacy_drive(s->flash[i],
-                                  drive_get(IF_PFLASH, 0, i));
-    }
-    vul_model_flash_map(s, system_memory);
 
     /* load/create device tree */
     if (machine->dtb) {
@@ -1374,8 +922,6 @@ static void vul_model_machine_instance_init(Object *obj)
 {
     RISCVVulModelState *s = RISCV_VUL_MODEL_MACHINE(obj);
 
-    vul_model_flash_create(s);
-
     s->oem_id = g_strndup(ACPI_BUILD_APPNAME6, 6);
     s->oem_table_id = g_strndup(ACPI_BUILD_APPNAME8, 8);
     s->acpi = ON_OFF_AUTO_AUTO;
@@ -1392,25 +938,9 @@ static HotplugHandler *vul_model_machine_get_hotplug_handler(MachineState *machi
     return NULL;
 }
 
-static void vul_model_machine_device_plug_cb(HotplugHandler *hotplug_dev,
-                                        DeviceState *dev, Error **errp)
-{
-    RISCVVulModelState *s = RISCV_VUL_MODEL_MACHINE(hotplug_dev);
-
-    if (s->platform_bus_dev) {
-        MachineClass *mc = MACHINE_GET_CLASS(s);
-
-        if (device_is_dynamic_sysbus(mc, dev)) {
-            platform_bus_link_device(PLATFORM_BUS_DEVICE(s->platform_bus_dev),
-                                     SYS_BUS_DEVICE(dev));
-        }
-    }
-}
-
 static void vul_model_machine_class_init(ObjectClass *oc, void *data)
 {
     MachineClass *mc = MACHINE_CLASS(oc);
-    HotplugHandlerClass *hc = HOTPLUG_HANDLER_CLASS(oc);
 
     mc->desc = "RISC-V Vulcano simulation board";
     mc->init = vul_model_machine_init;
@@ -1426,8 +956,6 @@ static void vul_model_machine_class_init(ObjectClass *oc, void *data)
     mc->default_ram_id = "riscv_vul_model_board.ram";
     assert(!mc->get_hotplug_handler);
     mc->get_hotplug_handler = vul_model_machine_get_hotplug_handler;
-
-    hc->plug = vul_model_machine_device_plug_cb;
 
     machine_class_allow_dynamic_sysbus_dev(mc, TYPE_RAMFB_DEVICE);
 #ifdef CONFIG_TPM

--- a/include/hw/misc/vul_csr.h
+++ b/include/hw/misc/vul_csr.h
@@ -15,15 +15,10 @@ OBJECT_DECLARE_SIMPLE_TYPE(VulCSRState, VUL_CSR);
  */
 #define VUL_CSR_SIZE (0x70000000ULL - 0x10000000ULL)
 
-#define VUL_CSR_ZMQ_BUF_SIZE 131072
-
 struct VulCSRState {
     SysBusDevice parent_obj;
     struct MemoryRegion mmio;
     hwaddr base_addr;
-    void *zmq_context;
-    void *zmq_socket;
-    char msg_buf[VUL_CSR_ZMQ_BUF_SIZE];
 };
 
 DeviceState *vul_csr_create(hwaddr addr);

--- a/include/hw/misc/vul_mem.h
+++ b/include/hw/misc/vul_mem.h
@@ -1,0 +1,19 @@
+#ifndef __HW_VUL_MEM_H
+#define __HW_VUL_MEM_H
+
+#include "hw/sysbus.h"
+#include "qom/object.h"
+
+#define TYPE_VUL_MEM "vul-mem"
+OBJECT_DECLARE_SIMPLE_TYPE(VulMemState, VUL_MEM);
+
+struct VulMemState {
+    SysBusDevice parent_obj;
+    struct MemoryRegion mmio;
+    hwaddr base_addr;
+    size_t region_size;
+};
+
+DeviceState *vul_mem_create(hwaddr addr, size_t region_size);
+
+#endif // __HW_VUL_MEM_H

--- a/include/hw/riscv/vul_model.h
+++ b/include/hw/riscv/vul_model.h
@@ -35,8 +35,6 @@ DECLARE_INSTANCE_CHECKER(RISCVVulModelState, RISCV_VUL_MODEL_MACHINE,
                          TYPE_RISCV_VUL_MODEL_MACHINE)
 
 typedef enum RISCVVulModelAIAType {
-    VUL_MODEL_AIA_TYPE_NONE = 0,
-    VUL_MODEL_AIA_TYPE_APLIC,
     VUL_MODEL_AIA_TYPE_APLIC_IMSIC,
 } RISCVVulModelAIAType;
 
@@ -46,11 +44,8 @@ struct RISCVVulModelState {
 
     /*< public >*/
     Notifier machine_done;
-    DeviceState *platform_bus_dev;
     RISCVHartArrayState soc[VUL_MODEL_SOCKETS_MAX];
     DeviceState *irqchip[VUL_MODEL_SOCKETS_MAX];
-    PFlashCFI01 *flash[2];
-    FWCfgState *fw_cfg;
     DeviceState *vul_csr;
 
     int fdt_size;
@@ -67,67 +62,28 @@ enum {
     VUL_MODEL_DEBUG,
     VUL_MODEL_MROM,
     VUL_MODEL_TEST,
-    VUL_MODEL_RTC,
     VUL_MODEL_CLINT,
-    VUL_MODEL_ACLINT_SSWI,
-    VUL_MODEL_PLIC,
     VUL_MODEL_APLIC_M,
     VUL_MODEL_APLIC_S,
     VUL_MODEL_UART0,
-    VUL_MODEL_VIRTIO,
-    VUL_MODEL_FW_CFG,
     VUL_MODEL_IMSIC_M,
     VUL_MODEL_IMSIC_S,
-    VUL_MODEL_FLASH,
+    VUL_MODEL_SRAM,
     VUL_MODEL_DRAM,
-    VUL_MODEL_PCIE_MMIO,
-    VUL_MODEL_PCIE_PIO,
-    VUL_MODEL_PLATFORM_BUS,
-    VUL_MODEL_PCIE_ECAM,
     VUL_MODEL_CSRS
 };
 
 enum {
     UART0_IRQ = 8,
-    /* Anything from here below makes no sense and needs fixing/removal */
-    RTC_IRQ = 11,
-    VIRTIO_IRQ = 1, /* 1 to 7 */
-    VIRTIO_COUNT = 7,
-    PCIE_IRQ = 0x20, /* 32 to 35 */
-    VIRT_PLATFORM_BUS_IRQ = 64, /* 64 to 95 */
 };
-
-#define VUL_MODEL_PLATFORM_BUS_NUM_IRQS 6
 
 #define VUL_MODEL_IRQCHIP_NUM_MSIS 511
 #define VUL_MODEL_IRQCHIP_NUM_SOURCES 70
 #define VUL_MODEL_IRQCHIP_NUM_PRIO_BITS 3
 #define VUL_MODEL_IRQCHIP_MAX_GUESTS_BITS 3
-#define VUL_MODEL_IRQCHIP_MAX_GUESTS ((1U << VUL_MODEL_IRQCHIP_MAX_GUESTS_BITS) - 1U)
 
-#define VUL_MODEL_PLIC_PRIORITY_BASE 0x00
-#define VUL_MODEL_PLIC_PENDING_BASE 0x1000
-#define VUL_MODEL_PLIC_ENABLE_BASE 0x2000
-#define VUL_MODEL_PLIC_ENABLE_STRIDE 0x80
-#define VUL_MODEL_PLIC_CONTEXT_BASE 0x200000
-#define VUL_MODEL_PLIC_CONTEXT_STRIDE 0x1000
-#define VUL_MODEL_PLIC_SIZE(__num_context) \
-    (VUL_MODEL_PLIC_CONTEXT_BASE + (__num_context) * VUL_MODEL_PLIC_CONTEXT_STRIDE)
-
-#define FDT_PCI_ADDR_CELLS    3
-#define FDT_PCI_INT_CELLS     1
-#define FDT_PLIC_ADDR_CELLS   0
-#define FDT_PLIC_INT_CELLS    1
 #define FDT_APLIC_INT_CELLS   2
 #define FDT_IMSIC_INT_CELLS   0
 #define FDT_MAX_INT_CELLS     2
-#define FDT_MAX_INT_MAP_WIDTH (FDT_PCI_ADDR_CELLS + FDT_PCI_INT_CELLS + \
-                                 1 + FDT_MAX_INT_CELLS)
-#define FDT_PLIC_INT_MAP_WIDTH  (FDT_PCI_ADDR_CELLS + FDT_PCI_INT_CELLS + \
-                                 1 + FDT_PLIC_INT_CELLS)
-#define FDT_APLIC_INT_MAP_WIDTH (FDT_PCI_ADDR_CELLS + FDT_PCI_INT_CELLS + \
-                                 1 + FDT_APLIC_INT_CELLS)
 
-bool vul_model_is_acpi_enabled(RISCVVulModelState *s);
-void virt_acpi_setup(RISCVVulModelState *vms);
 #endif // HW_RISCV_VUL_MODEL_H

--- a/include/hw/riscv/vul_model.h
+++ b/include/hw/riscv/vul_model.h
@@ -47,9 +47,12 @@ struct RISCVVulModelState {
     RISCVHartArrayState soc[VUL_MODEL_SOCKETS_MAX];
     DeviceState *irqchip[VUL_MODEL_SOCKETS_MAX];
     DeviceState *vul_csr;
+    DeviceState *vul_mem;
 
     int fdt_size;
     bool have_aclint;
+    bool use_ssram;
+    size_t nicram_size;
     RISCVVulModelAIAType aia_type;
     int aia_guests;
     char *oem_id;

--- a/include/vul_zmq.h
+++ b/include/vul_zmq.h
@@ -1,6 +1,7 @@
 #ifndef __UTIL_VUL_UTIL_H
 #define __UTIL_VUL_UTIL_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #define VUL_ZMQ_BUF_SIZE 131072
@@ -16,5 +17,8 @@ void vul_zmq_init(void);
 /* The Vulcano model operates with the expectation only 32b register read/writes can happen */
 uint32_t vul_zmq_read_csr(uint64_t addr);
 void vul_zmq_write_csr(uint64_t addr, uint32_t data);
+
+void vul_zmq_read_mem(uint64_t addr, uint8_t *data, size_t size);
+void vul_zmq_write_mem(uint64_t addr, uint8_t *data, size_t size);
 
 #endif // __UTIL_VUL_UTIL_H

--- a/include/vul_zmq.h
+++ b/include/vul_zmq.h
@@ -1,0 +1,20 @@
+#ifndef __UTIL_VUL_UTIL_H
+#define __UTIL_VUL_UTIL_H
+
+#include <stdint.h>
+
+#define VUL_ZMQ_BUF_SIZE 131072
+
+typedef struct vul_zmq_ctx_s {
+    void *zmq_context;
+    void *zmq_socket;
+    char msg_buf[VUL_ZMQ_BUF_SIZE];
+} vul_zmq_ctx;
+
+void vul_zmq_init(void);
+
+/* The Vulcano model operates with the expectation only 32b register read/writes can happen */
+uint32_t vul_zmq_read_csr(uint64_t addr);
+void vul_zmq_write_csr(uint64_t addr, uint32_t data);
+
+#endif // __UTIL_VUL_UTIL_H

--- a/util/meson.build
+++ b/util/meson.build
@@ -119,3 +119,11 @@ elif cpu == 'loongarch64'
 elif cpu in ['ppc', 'ppc64']
   util_ss.add(files('cpuinfo-ppc.c'))
 endif
+
+# Using CONFIG_VUL_MODEL because utils don't have their own KConfig...
+util_ss.add(when: 'CONFIG_VUL_MODEL', if_true: files('vul_zmq.c'))
+# Meson forces us to pass the dependency this way: if CONFIG_VUL_MODEL is not defined, it'll still try to check for
+# libzmq availabilty and this is not ok
+if config_target.get('CONFIG_VUL_MODEL', 'n') == 'y'
+  util_ss.add(dependency('libzmq'))
+endif

--- a/util/vul_zmq.c
+++ b/util/vul_zmq.c
@@ -142,6 +142,12 @@ uint32_t vul_zmq_read_csr(uint64_t addr)
         exit(1);
     }
 
+    if (msg->type != VUL_MODEL_MSG_OPCODE_STATUS && msg->status != 0) {
+        fprintf(stderr, "%s @ 0x%lx unexpected server response: type = %d, status = %d\n",
+                __func__, addr, msg->type, msg->status);
+        exit(1);
+    }
+
     uint32_t reg_read;
     memcpy(&reg_read, msg->data, sizeof(uint32_t));
     return reg_read;
@@ -170,6 +176,12 @@ void vul_zmq_write_csr(uint64_t addr, uint32_t data)
     rc = zmq_recv(ctx.zmq_socket, ctx.msg_buf, sizeof(ctx.msg_buf), 0);
     if (rc < 0) {
         fprintf(stderr, "Error while receiving CSR write response\n");
+        exit(1);
+    }
+
+    if (msg->type != VUL_MODEL_MSG_OPCODE_STATUS && msg->status != 0) {
+        fprintf(stderr, "%s @ 0x%lx -> 0x%x unexpected server response: type = %d, status = %d\n",
+                __func__, addr, data, msg->type, msg->status);
         exit(1);
     }
 }
@@ -207,6 +219,12 @@ void vul_zmq_read_mem(uint64_t addr, uint8_t *data, size_t size)
         exit(1);
     }
 
+    if (msg->type != VUL_MODEL_MSG_OPCODE_STATUS && msg->status != 0) {
+        fprintf(stderr, "%s @ 0x%lx unexpected server response: type = %d, status = %d\n",
+                __func__, addr, msg->type, msg->status);
+        exit(1);
+    }
+
     memcpy(data, msg->data, size);
 }
 
@@ -237,6 +255,17 @@ void vul_zmq_write_mem(uint64_t addr, uint8_t *data, size_t size)
     rc = zmq_recv(ctx.zmq_socket, ctx.msg_buf, sizeof(ctx.msg_buf), 0);
     if (rc < 0) {
         fprintf(stderr, "Error while receiving memory write response\n");
+        exit(1);
+    }
+
+    if (msg->type != VUL_MODEL_MSG_OPCODE_STATUS && msg->status != 0) {
+        fprintf(stderr, "%s @ 0x%lx unexpected server response: type = %d, status = %d. Data dump:\n",
+                __func__, addr, msg->type, msg->status);
+        for (unsigned i = 0; i < size; i++) {
+            fprintf(stderr, "%hhx ", data[i]);
+        }
+
+        fprintf(stderr, "\n");
         exit(1);
     }
 }

--- a/util/vul_zmq.c
+++ b/util/vul_zmq.c
@@ -1,0 +1,175 @@
+#include <memory.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <zmq.h>
+
+#include "vul_zmq.h"
+
+static vul_zmq_ctx ctx;
+
+/* The vul_model_* types _MUST_ be kept in sync with the model */
+typedef enum vul_model_msg_opcode_e {
+    VUL_MODEL_MSG_OPCODE_STEP_PKT = 0,
+    VUL_MODEL_MSG_OPCODE_GET_NEXT_PKT = 1,
+    VUL_MODEL_MSG_OPCODE_REG_READ = 2,
+    VUL_MODEL_MSG_OPCODE_REG_WRITE = 3,
+    VUL_MODEL_MSG_OPCODE_MEM_READ = 4,
+    VUL_MODEL_MSG_OPCODE_MEM_WRITE = 5,
+    VUL_MODEL_MSG_OPCODE_DOORBELL = 6,
+    VUL_MODEL_MSG_OPCODE_STATUS = 7,
+    VUL_MODEL_MSG_OPCODE_HBM_DUMP = 8,
+    VUL_MODEL_MSG_OPCODE_STEP_CPU_PKT = 9,
+    VUL_MODEL_MSG_OPCODE_GET_NEXT_CPU_PKT = 10,
+    VUL_MODEL_MSG_OPCODE_STEP_TIMER_WHEEL = 11,
+    VUL_MODEL_MSG_OPCODE_MAC_CFG = 12,
+    VUL_MODEL_MSG_OPCODE_MAC_EN = 13,
+    VUL_MODEL_MSG_OPCODE_MAC_SOFT_RESET = 14,
+    VUL_MODEL_MSG_OPCODE_MAC_STATS_RESET = 15,
+    VUL_MODEL_MSG_OPCODE_MAC_INTR_EN = 16,
+    VUL_MODEL_MSG_OPCODE_MAC_INTR_CLR = 17,
+    VUL_MODEL_MSG_OPCODE_REGISTER_MEM_ADDR = 18,
+    VUL_MODEL_MSG_OPCODE_EXIT_SIM = 19,
+    VUL_MODEL_MSG_OPCODE_CONFIG_DONE = 20,
+    VUL_MODEL_MSG_OPCODE_TESTCASE_BEGIN = 21,
+    VUL_MODEL_MSG_OPCODE_TESTCASE_END = 22,
+    VUL_MODEL_MSG_OPCODE_EOS_IGNORE_ADDR = 23,
+    VUL_MODEL_MSG_OPCODE_MEM_WRITE_PCIE = 24,
+    VUL_MODEL_MSG_OPCODE_MEM_RESET = 25,
+    VUL_MODEL_MSG_OPCODE_SET_LOG_LEVEL = 26,
+    VUL_MODEL_MSG_OPCODE_SET_TIME = 27,
+    VUL_MODEL_MSG_OPCODE_GET_TIME = 28,
+} vul_model_msg_opcode_t;
+
+typedef struct vul_model_port_s {
+    uint32_t    speed;      // port speed to configure
+    uint32_t    val;        // used for reset/enable
+    uint32_t    num_lanes;  // number of lanes for this port
+} vul_model_port_t;
+
+typedef struct vul_model_msg_s {
+    vul_model_msg_opcode_t type;
+    union {
+        int         size;
+        int         tcid;
+        int         log_level;
+    };
+    union {
+        int         port;   // also used for mac port num
+        int         loopid;
+        uint32_t    entry_size;
+        int         log_mpu;
+    };
+    int         cos;
+    int         status;
+    uint32_t    slowfast;
+    uint32_t    ctime;
+    uint32_t    pad;
+    uint64_t    addr;
+    uint8_t     data[0];    // custom data
+} vul_model_msg_t;
+
+static inline void zmq_endpoint(char *endpoint, size_t len)
+{
+    const char *user_str = getenv("ZMQ_SOC_DIR");
+    char *model_socket_name = NULL;
+    char *model_server_ip = NULL;
+
+    if (getenv("MODEL_ZMQ_TYPE_TCP")) {
+        model_socket_name = getenv("MODEL_ZMQ_TCP_PORT");
+        if (model_socket_name == NULL) {
+            model_socket_name = (char *) "50055";
+        }
+
+        model_server_ip = getenv("MODEL_ZMQ_SERVER_IP");
+        if (model_server_ip == NULL) {
+            model_server_ip = (char *) "0.0.0.0";
+        }
+
+        snprintf(endpoint, len, "tcp://%s:%s", model_server_ip, model_socket_name);
+    } else {
+        model_socket_name = getenv("MODEL_SOCKET_NAME");
+        if (model_socket_name == NULL) {
+            model_socket_name = (char *)"zmqsock";
+        }
+
+        snprintf(endpoint, len, "ipc:///%s/%s", user_str, model_socket_name);
+    }
+}
+
+void vul_zmq_init(void)
+{
+    char endpoint[256];
+
+    ctx.zmq_context = zmq_ctx_new();
+    if (!ctx.zmq_context) {
+        fprintf(stderr, "Couldn't create the ZMQ context\n");
+        exit(1);
+    }
+
+    ctx.zmq_socket = zmq_socket(ctx.zmq_context, ZMQ_REQ);
+    if (!ctx.zmq_socket) {
+        fprintf(stderr, "Couldn't create the ZMQ socket\n");
+        exit(1);
+    }
+
+    zmq_endpoint(endpoint, sizeof(endpoint));
+    if (zmq_connect(ctx.zmq_socket, endpoint) != 0) {
+        fprintf(stderr, "ZMQ connection failed\n");
+        exit(1);
+    }
+}
+
+uint32_t vul_zmq_read_csr(uint64_t addr)
+{
+    vul_model_msg_t *msg = (vul_model_msg_t *)ctx.msg_buf;
+
+    memset(msg, 0, sizeof(vul_model_msg_t) + sizeof(uint64_t));
+    *msg = (vul_model_msg_t) {
+        .type = VUL_MODEL_MSG_OPCODE_REG_READ,
+        .addr = addr,
+        .size = sizeof(uint32_t),
+    };
+
+    int rc = zmq_send(ctx.zmq_socket, msg, sizeof(vul_model_msg_t), 0);
+    if (rc < 0) {
+        fprintf(stderr, "Error while sending CSR read request\n");
+        exit(1);
+    }
+
+    rc = zmq_recv(ctx.zmq_socket, ctx.msg_buf, sizeof(ctx.msg_buf), 0);
+    if (rc < 0) {
+        fprintf(stderr, "Error while receiving CSR read response\n");
+        exit(1);
+    }
+
+    uint32_t reg_read;
+    memcpy(&reg_read, msg->data, sizeof(uint32_t));
+    return reg_read;
+}
+
+void vul_zmq_write_csr(uint64_t addr, uint32_t data)
+{
+    vul_model_msg_t *msg = (vul_model_msg_t *)ctx.msg_buf;
+
+    memset(msg, 0, sizeof(vul_model_msg_t) + sizeof(uint64_t));
+    *msg = (vul_model_msg_t) {
+        .type = VUL_MODEL_MSG_OPCODE_REG_WRITE,
+        .addr = addr,
+        .size = sizeof(uint32_t),
+        .entry_size = (1 << 16) | 1, /* Magic bits to implement a 32b write. See model's code for mode details */
+    };
+
+    memcpy(msg->data, &data, sizeof(data));
+
+    int rc = zmq_send(ctx.zmq_socket, msg, sizeof(vul_model_msg_t) + sizeof(uint32_t), 0);
+    if (rc < 0) {
+        fprintf(stderr, "Error while sending CSR write request\n");
+        exit(1);
+    }
+
+    rc = zmq_recv(ctx.zmq_socket, ctx.msg_buf, sizeof(ctx.msg_buf), 0);
+    if (rc < 0) {
+        fprintf(stderr, "Error while receiving CSR write response\n");
+        exit(1);
+    }
+}

--- a/util/vul_zmq.c
+++ b/util/vul_zmq.c
@@ -173,3 +173,70 @@ void vul_zmq_write_csr(uint64_t addr, uint32_t data)
         exit(1);
     }
 }
+
+void vul_zmq_read_mem(uint64_t addr, uint8_t *data, size_t size)
+{
+    vul_model_msg_t *msg = (vul_model_msg_t *)ctx.msg_buf;
+
+    if (size >= VUL_ZMQ_BUF_SIZE - sizeof(vul_model_msg_t)) {
+        fprintf(stderr, "%s: msg is too big! (%lu >= %lu)\n", __func__, size,
+                VUL_ZMQ_BUF_SIZE - sizeof(vul_model_msg_t));
+        exit(1);
+    }
+
+    memset(msg, 0, sizeof(vul_model_msg_t));
+    *msg = (vul_model_msg_t) {
+        .type = VUL_MODEL_MSG_OPCODE_MEM_READ,
+        .addr = addr,
+        .size = size,
+    };
+
+    int rc = zmq_send(ctx.zmq_socket, msg, sizeof(vul_model_msg_t), 0);
+    if (rc < 0) {
+        fprintf(stderr, "Error while sending memory read request\n");
+        exit(1);
+    }
+
+    rc = zmq_recv(ctx.zmq_socket, ctx.msg_buf, sizeof(ctx.msg_buf), 0);
+    if (rc < 0) {
+        fprintf(stderr, "Error while receiving memory read response\n");
+        exit(1);
+    } else if (rc != size + sizeof(vul_model_msg_t)) {
+        fprintf(stderr, "Memory read received less data than required: %d != %lu\n", rc,
+                size + sizeof(vul_model_msg_t));
+        exit(1);
+    }
+
+    memcpy(data, msg->data, size);
+}
+
+void vul_zmq_write_mem(uint64_t addr, uint8_t *data, size_t size)
+{
+    vul_model_msg_t *msg = (vul_model_msg_t *)ctx.msg_buf;
+
+    if (size >= VUL_ZMQ_BUF_SIZE - sizeof(vul_model_msg_t)) {
+        fprintf(stderr, "%s: msg is too big! (%lu >= %lu)\n", __func__, size,
+                VUL_ZMQ_BUF_SIZE - sizeof(vul_model_msg_t));
+        exit(1);
+    }
+
+    memset(msg, 0, sizeof(vul_model_msg_t));
+    *msg = (vul_model_msg_t) {
+        .type = VUL_MODEL_MSG_OPCODE_MEM_WRITE,
+        .addr = addr,
+        .size = size,
+    };
+    memcpy(msg->data, data, size);
+
+    int rc = zmq_send(ctx.zmq_socket, msg, sizeof(vul_model_msg_t) + size, 0);
+    if (rc < 0) {
+        fprintf(stderr, "Error while sending memory write request\n");
+        exit(1);
+    }
+
+    rc = zmq_recv(ctx.zmq_socket, ctx.msg_buf, sizeof(ctx.msg_buf), 0);
+    if (rc < 0) {
+        fprintf(stderr, "Error while receiving memory write response\n");
+        exit(1);
+    }
+}


### PR DESCRIPTION
We need to share some memory with the model to ensure things like config space are properly presented to the host. For this purpose, we add a new MMIo device able to redirect memory accesses performed by FW to the model.

The reason we use the SRAM as default QEMU RAM, rather than something else, is due to the fact that QEMU rounds the LLC memory size. Because we don't want to place restrictions on how big the memory shared with the model is, that can't work with the LLC. So, instead, we allocate the LLC to the precise amount we need internally.

Command line examples.

Booting from an ELF file:
```
ZMQ_SOC_DIR=/sw/nic /sw/platform/src/sim/qemu/external-qemu/riscv-build/qemu-system-riscv64 -nographic -machine vul_model,ssram=false,nicram=20k -bios none -m 512k -net none -pidfile qemu.pid -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -icount shift=6,align=off,sleep=off -rtc clock=vm -kernel /sw/zephyr.elf
```

Or, when booting from SRAM:
```
ZMQ_SOC_DIR=/sw/nic /sw/platform/src/sim/qemu/external-qemu/riscv-build/qemu-system-riscv64 -nographic -machine vul_model,ssram=true,nicram=20k -bios none -m 512k -net none -pidfile qemu.pid -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -icount shift=6,align=off,sleep=off -rtc clock=vm -device loader,file=/sw/zephyr_patched.bin,addr=0x400000
```