### PR TITLE
VSW-286: HACK: force simbridge to handle extended config space

### DIFF
--- a/hw/pci-bridge/simbridge.c
+++ b/hw/pci-bridge/simbridge.c
@@ -539,6 +539,9 @@ static SimDevice *simbridge_register_dev(SimBridgeDn *sbdn, int simbdf)
 
     bus = BUS(&(PCI_BRIDGE(sbdn)->sec_bus));
     qdev_set_parent_bus(dev, bus, &err);
+    PCIBus *pcibus = PCI_BUS(bus);
+    /* VSW-286: this is definitely not the proper way of doing this */
+    pcibus->flags |= PCI_BUS_EXTENDED_CONFIG_SPACE;
     object_property_set_bool(obj, "realized", true, NULL);
 
     simdevices_add(sd);
@@ -572,6 +575,9 @@ static SimBridgeDn *simbridge_register_bridge(SimBridge *sb, int simbdf)
 
     bus = BUS(&(PCI_BRIDGE(sb)->sec_bus));
     qdev_set_parent_bus(dev, bus, &err);
+    PCIBus *pcibus = PCI_BUS(bus);
+    /* VSW-286: this is definitely not the proper way of doing this */
+    pcibus->flags |= PCI_BUS_EXTENDED_CONFIG_SPACE;
     object_property_set_bool(obj, "realized", true, NULL);
     return sbdn;
 }


### PR DESCRIPTION
For reasons not completely understood, something is going wrong in QEMU's object model and the correct realise function setting up the PCI_BUS_EXTENDED_CONFIG_SPACE for a downstream port isn't being called. Because of this, QEMU autonomously replies with all 1s when host software tries to access extended capabilities of an endpoint implemented in the model, without ever trying to invoke the simbridge code.

This workaround is dirty, but unblocks us as it forces QEMU to forward us extended config space access.