### PR TITLE
simbridge: VF BAR map fixes

### DIFF
--- a/hw/pci-bridge/simbridge.c
+++ b/hw/pci-bridge/simbridge.c
@@ -282,10 +282,11 @@ static void simdevice_cfgwr(PCIDevice *pd,
     u_int64_t val = data;
 
     /*
-     * Send this write down to pci layer to update
+     * Send PF writes down to pci layer to update
      * bar addresses when they come.
      */
-    pci_default_write_config(pd, addr, data, len);
+    if (!pci_is_vf(pd))
+        pci_default_write_config(pd, addr, data, len);
 
     if (simc_cfgwr(sd->simbdf, addr, len, val) < 0) {
         dbgprintf("simdevice_cfgwr(0x%04x, 0x%x, %d) = 0x%"PRIx64" failed\n",

--- a/hw/pci/pcie_sriov.c
+++ b/hw/pci/pcie_sriov.c
@@ -112,6 +112,9 @@ void pcie_sriov_vf_register_bar(PCIDevice *dev, int region_num,
     PCIBus *bus = pci_get_bus(dev);
     uint8_t type;
     pcibus_t size = memory_region_size(memory);
+    PCIDevice *pf = dev->exp.sriov_vf.pf;
+    uint16_t pf_ctrl = pci_get_word(pf->config + pf->exp.sriov_cap + PCI_SRIOV_CTRL);
+    uint16_t command = pci_get_word(dev->config + PCI_COMMAND);
 
     assert(pci_is_vf(dev)); /* PFs must use pci_register_bar */
     assert(region_num >= 0);
@@ -133,6 +136,14 @@ void pcie_sriov_vf_register_bar(PCIDevice *dev, int region_num,
         : bus->address_space_mem;
     r->size = size;
     r->type = type;
+
+    /* pci_bar_address checks the command word and returns UNMAPPED if the MSE bit is
+     * not set, so we propagate the MSE bit from the PF's SRIOV register. */
+    if (pf_ctrl & PCI_SRIOV_CTRL_MSE)
+        command |= PCI_COMMAND_MEMORY;
+    else
+        command &= ~PCI_COMMAND_MEMORY;
+    pci_set_word(dev->config + PCI_COMMAND, command);
 
     r->addr = pci_bar_address(dev, region_num, r->type, r->size);
     if (r->addr != PCI_BAR_UNMAPPED) {


### PR DESCRIPTION
With this PR, we map the VF bar from `pcie_sriov_vf_register_bar` if VF_MSE is set on the PF's sriov capability.