### PR TITLE
Add basic support for ATS request/response and Translated memory ops

### DIFF
--- a/hw/pci-bridge/simbridge.c
+++ b/hw/pci-bridge/simbridge.c
@@ -935,6 +935,74 @@ process_memwr(int fd, simmsg_t *m)
     simc_writeres(bdf, addr, size, 0);
 }
 
+static int
+process_ats_translate(int fd, simmsg_t *m)
+{
+    const u_int16_t bdf  = m->u.ats_req.bdf;
+    const u_int64_t addr = m->u.ats_req.addr;
+    const u_int32_t length = m->u.ats_req.length;
+    const u_int32_t size = length * sizeof(uint64_t);
+    const bool no_write = m->u.ats_req.addr & 1;
+    char buf[4096];
+    ssize_t res;
+
+    dbgprintf("ats_translate: bdf %04x addr 0x%"PRIx64" length 0x%x\n",
+              bdf, addr, length);
+
+    if (size > sizeof(buf)) {
+        dbgprintf("process_ats_translate: request size too large: 0x%x\n", size);
+        simc_atsres(bdf, addr, size, NULL, E2BIG);
+        return -1;
+    }
+
+    if (bdf) {
+        SimDevice *sd;
+        PCIDevice *pd;
+        IOMMUTLBEntry entries[sizeof(buf) / sizeof(uint64_t)];
+        uint32_t err_count;
+        int i;
+
+        /*
+         * bdf was provided so use that device context for memory access.
+         */
+        sd = simdevices_find_bdf(bdf);
+        if (sd == NULL) {
+            dbgprintf("process_ats_translate: bdf %04x not found\n", bdf);
+            simc_atsres(bdf, addr, length, NULL, ENODEV);
+            return -1;
+        }
+        pd = PCI_DEVICE(sd);
+        /* assume STU 0 as that's what Qemu only supports */
+        res = pci_ats_request_translation(pd, PCI_NO_PASID, false, false,
+                                          addr, length * 4096, no_write, entries,
+                                          ARRAY_SIZE(entries), &err_count);
+        if (res < 0) {
+            u_int8_t error = (u_int8_t)-res;
+            dbgprintf("process_ats_translate: translation error %d\n", error);
+            simc_atsres(bdf, addr, length, NULL, error);
+            return -1;
+        }
+        /* positive err_count is not an error in itself and ATC should cope */
+        dbgprintf("process_ats_translate: error count %d\n", err_count);
+        for (i = 0; i < res; i++) {
+            uint64_t *result = (uint64_t *)buf;
+            result[i] = (entries[i].translated_addr & ~entries[i].addr_mask);
+            /* the expression below corresponds to Table 10-5 of PCIe spec */
+            result[i] |= (entries[i].addr_mask >> 1) & ~((1UL << 11) - 1);
+            result[i] |= (entries[i].perm & IOMMU_RW);
+            dbgprintf("entry[%d] = 0x%lx: addr=%lx mask=%lx perm=%x\n", i, result[i],
+                      entries[i].translated_addr, entries[i].addr_mask, entries[i].perm);
+        }
+    } else {
+        dbgprintf("process_ats_translate: no bdf given\n");
+        simc_atsres(bdf, addr, length, NULL, EINVAL);
+        return -1;
+    }
+
+    dbgprinthex(4, (u_int8_t *)buf, res * sizeof(uint64_t));
+    return simc_atsres(bdf, addr, res, buf, 0);
+}
+
 static void
 msg_handler(int fd, simmsg_t *m)
 {
@@ -949,6 +1017,9 @@ msg_handler(int fd, simmsg_t *m)
         break;
     case SIMMSG_SYNC_REQ:
         simc_sync_ack();
+        break;
+    case SIMMSG_ATS_REQ:
+        process_ats_translate(fd, m);
         break;
     default:
         dbgprintf("unknown msg type %d\n", m->msgtype);

--- a/hw/pci-bridge/simbridge.c
+++ b/hw/pci-bridge/simbridge.c
@@ -513,16 +513,16 @@ static void simdevice_msix_init(SimDevice *sd)
     return;
 }
 
-static uint16_t simdevice_find_sriov_cap(PCIDevice *pd, int simbdf) {
+static uint16_t simdevice_find_ext_cap(PCIDevice *pd, int simbdf, int ext_cap) {
     uint16_t offset = PCI_CFG_SPACE_SIZE;
     uint64_t val;
 
     while (offset && simc_cfgrd(simbdf, offset, 4, &val) == 0) {
-        /* NOTE: pcie_sriov_pf_init() relies on dev->config having the chain
-         * of capability headers leading to the SR-IOV capability, so we
+        /* NOTE: QEMU relies on dev->config having the chain
+         * of capability headers leading to the requested capability, so we
          * propagate them here. */
         pci_set_long(pd->config + offset, val);
-        if (PCI_EXT_CAP_ID(val) == PCI_EXT_CAP_ID_SRIOV)
+        if (PCI_EXT_CAP_ID(val) == ext_cap)
             return offset;
         offset = PCI_EXT_CAP_NEXT(val);
     }
@@ -532,7 +532,8 @@ static uint16_t simdevice_find_sriov_cap(PCIDevice *pd, int simbdf) {
 static void simdevice_realize(PCIDevice *pd, Error **errp)
 {
     SimDevice *sd = (SimDevice *)pd;
-    u_int16_t sriov_cap_offset = simdevice_find_sriov_cap(pd, sd->simbdf);
+    u_int16_t sriov_cap_offset = simdevice_find_ext_cap(pd, sd->simbdf, PCI_EXT_CAP_ID_SRIOV);
+    u_int16_t ats_cap_offset = simdevice_find_ext_cap(pd, sd->simbdf, PCI_EXT_CAP_ID_ATS);
 
     simdevice_register_bars(sd);
     simdevice_msix_init(sd);
@@ -567,6 +568,17 @@ static void simdevice_realize(PCIDevice *pd, Error **errp)
             if (props.size)
                 pcie_sriov_pf_init_vf_bar(pd, baridx, props.type, props.size);
         }
+    }
+
+    if (ats_cap_offset) {
+        uint64_t ats_cap;
+
+        if (simc_cfgrd(sd->simbdf, ats_cap_offset + PCI_ATS_CAP, 2, &ats_cap) != 0)
+            return;
+
+        dbgprintf("%s: ats_cap=%d page_aligned=%s\n", __func__, ats_cap_offset,
+                  (ats_cap & PCI_ATS_CAP_PAGE_ALIGNED) ? "true" : "false");
+        pcie_ats_init(pd, ats_cap_offset, ats_cap & PCI_ATS_CAP_PAGE_ALIGNED);
     }
 
     simdevices_add(sd);

--- a/hw/pci-bridge/simbridge.c
+++ b/hw/pci-bridge/simbridge.c
@@ -658,9 +658,6 @@ static SimDevice *simbridge_register_dev(SimBridgeDn *sbdn, int simbdf,
 
     bus = BUS(&(PCI_BRIDGE(sbdn)->sec_bus));
     qdev_set_parent_bus(dev, bus, &err);
-    PCIBus *pcibus = PCI_BUS(bus);
-    /* VSW-286: this is definitely not the proper way of doing this */
-    pcibus->flags |= PCI_BUS_EXTENDED_CONFIG_SPACE;
     object_property_set_bool(obj, "realized", true, NULL);
     return sd;
 }
@@ -691,9 +688,6 @@ static SimBridgeDn *simbridge_register_bridge(SimBridge *sb, int simbdf)
 
     bus = BUS(&(PCI_BRIDGE(sb)->sec_bus));
     qdev_set_parent_bus(dev, bus, &err);
-    PCIBus *pcibus = PCI_BUS(bus);
-    /* VSW-286: this is definitely not the proper way of doing this */
-    pcibus->flags |= PCI_BUS_EXTENDED_CONFIG_SPACE;
     object_property_set_bool(obj, "realized", true, NULL);
     return sbdn;
 }
@@ -1174,6 +1168,7 @@ static void simbridge_init(SimBridge *sb)
 static void simbridge_realizefn(PCIDevice *d, Error **errp)
 {
     PCIEPort *p = PCIE_PORT(d);
+    PCIBridge *pb = PCI_BRIDGE(d);
     int rc;
 
     pci_bridge_initfn(d, TYPE_PCIE_BUS);
@@ -1208,6 +1203,10 @@ static void simbridge_realizefn(PCIDevice *d, Error **errp)
         goto err;
     }
 
+    // VSW-286: since we are going to realize child buses now directly
+    // (instead of relying on command line driven mechanism) - we need to
+    // preset our bus flags for the propagation logic in pci.c to pick up
+    pb->sec_bus.flags |= PCI_BUS_EXTENDED_CONFIG_SPACE;
     simbridge_init(SIM_BRIDGE(d));
     return;
 

--- a/hw/pci-bridge/simbridge.c
+++ b/hw/pci-bridge/simbridge.c
@@ -320,7 +320,7 @@ simdevice_memrd(void *opaque, hwaddr addr, unsigned size)
 
     /* add bar as model expects physical address */
     addr += simbar->sd->bar[baridx].addr;
-    if (simc_memrd(bdf, baridx, addr, size, &val) < 0) {
+    if (simc_memrd(bdf, baridx, addr, size, 0, &val) < 0) {
         dbgprintf("simdevice_memrd(0x%"PRIx64", 0x%x) failed%s\n",
                   addr, size, LOG_4B_UNALIGNED(addr));
         val = 0xffffffffffffffffULL;
@@ -340,7 +340,7 @@ simdevice_memwr(void *opaque, hwaddr addr, uint64_t val, unsigned size)
 
     /* add bar as model expects physical address */
     addr += simbar->sd->bar[baridx].addr;
-    if (simc_memwr(bdf, baridx, addr, size, val) < 0) {
+    if (simc_memwr(bdf, baridx, addr, size, 0, val) < 0) {
         dbgprintf("simdevice_memwr(0x%"PRIx64", 0x%x, 0x%"PRIx64") failed%s\n",
                   addr, size, val, LOG_4B_UNALIGNED(addr));
     } else {
@@ -860,10 +860,11 @@ process_memrd(int fd, simmsg_t *m)
     const u_int16_t bdf = m->u.read.bdf;
     const u_int64_t addr = m->u.read.addr;
     const u_int32_t size = m->u.read.size;
+    const u_int8_t flags = m->u.read.flags;
     char buf[4096];
 
-    dbgprintf("memrd: bdf %04x addr 0x%"PRIx64" size 0x%x\n",
-              bdf, addr, size);
+    dbgprintf("memrd: bdf %04x addr 0x%"PRIx64" size 0x%x flags 0x%x\n",
+              bdf, addr, size, flags);
 
     if (size > sizeof(buf)) {
         dbgprintf("process_memrd: read size too large: 0x%x\n", size);
@@ -885,7 +886,9 @@ process_memrd(int fd, simmsg_t *m)
             return -1;
         }
         pd = PCI_DEVICE(sd);
-        if (pci_dma_read(pd, addr, buf, size) != MEMTX_OK) {
+        if (pcie_ats_enabled(pd) && (flags & SIMMSG_FLAGS_TRANSLATED)) {
+            cpu_physical_memory_rw(addr, (uint8_t *)buf, size, 0);
+        } else if (pci_dma_read(pd, addr, buf, size) != MEMTX_OK) {
             dbgprintf("process_memrd: pci_dma_read 0x%"PRIx64" 0x%x failed\n",
                       addr, size);
             simc_readres(bdf, addr, size, NULL, EFAULT);
@@ -906,10 +909,11 @@ process_memwr(int fd, simmsg_t *m)
     const u_int16_t bdf  = m->u.write.bdf;
     const u_int64_t addr = m->u.write.addr;
     const u_int32_t size = m->u.write.size;
+    const u_int8_t flags = m->u.write.flags;
     char buf[4096];
 
-    dbgprintf("memwr: bdf %04x addr 0x%"PRIx64" size 0x%x\n",
-              bdf, addr, size);
+    dbgprintf("memwr: bdf %04x addr 0x%"PRIx64" size 0x%x flags 0x%x\n",
+              bdf, addr, size, flags);
 
     if (size > sizeof(buf)) {
         dbgprintf("process_memwr: write size too large: 0x%x\n", size);
@@ -933,7 +937,11 @@ process_memwr(int fd, simmsg_t *m)
             return;
         }
         pd = PCI_DEVICE(sd);
-        pci_dma_write(pd, addr, buf, size);
+        if (pcie_ats_enabled(pd) && (flags & SIMMSG_FLAGS_TRANSLATED)) {
+            cpu_physical_memory_rw(addr, (uint8_t *)buf, size, 1);
+        } else {
+            pci_dma_write(pd, addr, buf, size);
+        }
     } else {
         /* no specific device bdf, use generic access */
         cpu_physical_memory_rw(addr, (uint8_t *)buf, size, 1);

--- a/hw/pci-bridge/simbridge_utils.c
+++ b/hw/pci-bridge/simbridge_utils.c
@@ -154,7 +154,7 @@ sim_wait_for_resp(int s, simmsgtype_t msgtype, simmsg_t *m,
 static int
 sim_do_read(int s, simmsgtype_t msgtype,
             u_int16_t bdf, u_int8_t bar,
-            u_int64_t addr, u_int32_t size, u_int64_t *val,
+            u_int64_t addr, u_int32_t size, u_int8_t flags, u_int64_t *val,
             msg_handler_t msg_handler)
 {
     int r;
@@ -164,6 +164,7 @@ sim_do_read(int s, simmsgtype_t msgtype,
         .u.read.bar = bar,
         .u.read.addr = addr,
         .u.read.size = size,
+        .u.read.flags = flags,
     };
 
     r = sim_writen(s, &m, sizeof(m));
@@ -181,7 +182,7 @@ sim_do_read(int s, simmsgtype_t msgtype,
 static int
 sim_do_write(int s, simmsgtype_t msgtype,
              u_int16_t bdf, u_int8_t bar,
-             u_int64_t addr, u_int32_t size, u_int64_t val,
+             u_int64_t addr, u_int32_t size, u_int8_t flags, u_int64_t val,
              msg_handler_t msg_handler, int sync)
 {
     int r;
@@ -191,6 +192,7 @@ sim_do_write(int s, simmsgtype_t msgtype,
         .u.write.bar = bar,
         .u.write.addr = addr,
         .u.write.size = size,
+        .u.write.flags = flags,
         .u.write.val = val,
     };
 
@@ -355,7 +357,7 @@ sim_socket(const char *addrstr, struct simsockaddr *a)
 static int
 simc_do_write(simmsgtype_t msgtype,
               u_int16_t bdf, u_int8_t bar,
-              u_int64_t addr, u_int8_t size, u_int64_t val)
+              u_int64_t addr, u_int8_t size, u_int8_t flags, u_int64_t val)
 {
     simclient_t *sc = &simclient;
     int s = sc->s;
@@ -364,7 +366,7 @@ simc_do_write(simmsgtype_t msgtype,
     if (!simclient.open) return -EBADF;
 
     do {
-        r = sim_do_write(s, msgtype, bdf, bar, addr, size, val,
+        r = sim_do_write(s, msgtype, bdf, bar, addr, size, flags, val,
                          sc->handler, sc->sync_writes);
     } while (r == -EAGAIN);
     return r;
@@ -373,7 +375,7 @@ simc_do_write(simmsgtype_t msgtype,
 static int
 simc_do_read(simmsgtype_t msgtype,
              u_int16_t bdf, u_int8_t bar,
-             u_int64_t addr, u_int8_t size, u_int64_t *val)
+             u_int64_t addr, u_int8_t size, u_int8_t flags, u_int64_t *val)
 {
     simclient_t *sc = &simclient;
     int s = sc->s;
@@ -382,7 +384,7 @@ simc_do_read(simmsgtype_t msgtype,
     if (!sc->open) return -EBADF;
 
     do  {
-        r = sim_do_read(s, msgtype, bdf, bar, addr, size, val, sc->handler);
+        r = sim_do_read(s, msgtype, bdf, bar, addr, size, flags, val, sc->handler);
     } while (r == -EAGAIN);
     return r;
 }
@@ -434,41 +436,41 @@ simc_close(void)
 int
 simc_cfgrd(u_int16_t bdf, u_int16_t addr, u_int8_t size, u_int64_t *val)
 {
-    return simc_do_read(SIMMSG_CFGRD, bdf, 0, addr, size, val);
+    return simc_do_read(SIMMSG_CFGRD, bdf, 0, addr, size, 0, val);
 }
 
 int
 simc_cfgwr(u_int16_t bdf, u_int16_t addr, u_int8_t size, u_int64_t val)
 {
-    return simc_do_write(SIMMSG_CFGWR, bdf, 0, addr, size, val);
+    return simc_do_write(SIMMSG_CFGWR, bdf, 0, addr, size, 0, val);
 }
 
 int
 simc_memrd(u_int16_t bdf, u_int8_t bar,
-           u_int64_t addr, u_int8_t size, u_int64_t *val)
+           u_int64_t addr, u_int8_t size, u_int8_t flags, u_int64_t *val)
 {
-    return simc_do_read(SIMMSG_MEMRD, bdf, bar, addr, size, val);
+    return simc_do_read(SIMMSG_MEMRD, bdf, bar, addr, size, flags, val);
 }
 
 int
 simc_memwr(u_int16_t bdf, u_int8_t bar,
-           u_int64_t addr, u_int8_t size, u_int64_t val)
+           u_int64_t addr, u_int8_t size, u_int8_t flags, u_int64_t val)
 {
-    return simc_do_write(SIMMSG_MEMWR, bdf, bar, addr, size, val);
+    return simc_do_write(SIMMSG_MEMWR, bdf, bar, addr, size, flags, val);
 }
 
 int
 simc_iord(u_int16_t bdf, u_int8_t bar,
           u_int16_t addr, u_int8_t size, u_int64_t *val)
 {
-    return simc_do_read(SIMMSG_IORD, bdf, bar, addr, size, val);
+    return simc_do_read(SIMMSG_IORD, bdf, bar, addr, size, 0, val);
 }
 
 int
 simc_iowr(u_int16_t bdf, u_int8_t bar,
           u_int16_t addr, u_int8_t size, u_int64_t val)
 {
-    return simc_do_write(SIMMSG_IOWR, bdf, bar, addr, size, val);
+    return simc_do_write(SIMMSG_IOWR, bdf, bar, addr, size, 0, val);
 }
 
 int

--- a/hw/pci-bridge/simbridge_utils.c
+++ b/hw/pci-bridge/simbridge_utils.c
@@ -513,6 +513,30 @@ simc_writeres(u_int16_t bdf,
 }
 
 int
+simc_atsres(u_int16_t bdf,
+            u_int64_t addr, u_int32_t length, void *buf, u_int8_t error)
+{
+    int s = simclient.s;
+    simmsg_t m = {
+        .msgtype = SIMMSG_ATS_RESP,
+        .u.ats_res.bdf = bdf,
+        .u.ats_res.addr = addr,
+        .u.ats_res.length = length,
+        .u.ats_res.error = error,
+    };
+    u_int32_t size = length * sizeof(uint64_t);
+    int r;
+
+    if (!simclient.open) return -EBADF;
+
+    r = sim_writen(s, &m, sizeof(m));
+    if (r >= 0 && error == 0) {
+        r = sim_writen(s, buf, size);
+    }
+    return r;
+}
+
+int
 simc_readn(void *buf, size_t size)
 {
     if (!simclient.open) return -EBADF;

--- a/hw/pci-bridge/simbridge_utils.h
+++ b/hw/pci-bridge/simbridge_utils.h
@@ -19,6 +19,10 @@ typedef enum simmsgtype_e {
     SIMMSG_SYNC_ACK,
     SIMMSG_SYNC_REL,
     SIMMSG_STEP_TIME,
+    SIMMSG_ATS_REQ,
+    SIMMSG_ATS_RESP,
+    SIMMSG_ATS_INV,
+    SIMMSG_ATS_INV_CPL,
 } simmsgtype_t;
 
 #define PACKED __attribute__((packed))
@@ -68,6 +72,28 @@ typedef struct simmsg_s {
         struct {
             u_int32_t delta_ms;
         } PACKED step_time;
+        // ats_req addr encodes NW flag like in spec
+        struct {
+            u_int16_t bdf;
+            u_int64_t addr;
+            u_int32_t length;
+        } PACKED ats_req;
+        // ats_res returns array of uint64_t - same format as in spec
+        struct {
+            u_int16_t bdf;
+            u_int64_t addr;
+            u_int32_t length;
+            u_int8_t  error;
+        } PACKED ats_res;
+        // ats_inv has same address encoding as in spec
+        struct {
+            u_int16_t bdf;
+            u_int64_t addr;
+        } PACKED ats_inv;
+        struct {
+            u_int16_t bdf;
+            u_int64_t addr;
+        } PACKED ats_inv_cpl;
         struct {
             /* room to grow without breaking existing clients */
             u_int8_t pad[64];
@@ -114,6 +140,8 @@ int simc_readres(u_int16_t bdf,
                  u_int64_t addr, u_int32_t size, void *buf, u_int8_t error);
 int simc_writeres(u_int16_t bdf,
                   u_int64_t addr, u_int32_t size, u_int8_t error);
+int simc_atsres(u_int16_t bdf,
+                u_int64_t addr, u_int32_t length, void *buf, u_int8_t error);
 
 int simc_recv(simmsg_t *m);
 int simc_recv_and_handle(void);

--- a/hw/pci-bridge/simbridge_utils.h
+++ b/hw/pci-bridge/simbridge_utils.h
@@ -27,6 +27,8 @@ typedef enum simmsgtype_e {
 
 #define PACKED __attribute__((packed))
 
+#define SIMMSG_FLAGS_TRANSLATED (1 << 0)
+
 typedef struct simmsg_s {
     u_int16_t magic;
     u_int16_t msgtype;
@@ -40,18 +42,21 @@ typedef struct simmsg_s {
             u_int8_t  bar;
             u_int64_t addr;
             u_int32_t size;
+            u_int8_t  flags;
         } PACKED generic;
         struct {
             u_int16_t bdf;
             u_int8_t  bar;
             u_int64_t addr;
             u_int32_t size;
+            u_int8_t  flags;
         } PACKED read;
         struct {
             u_int16_t bdf;
             u_int8_t  bar;
             u_int64_t addr;
             u_int32_t size;
+            u_int8_t  flags;
             u_int64_t val;
             u_int8_t  error;
         } PACKED readres;
@@ -60,6 +65,7 @@ typedef struct simmsg_s {
             u_int8_t  bar;
             u_int64_t addr;
             u_int32_t size;
+            u_int8_t  flags;
             u_int64_t val;
         } PACKED write;
         struct {
@@ -67,6 +73,7 @@ typedef struct simmsg_s {
             u_int8_t  bar;
             u_int64_t addr;
             u_int32_t size;
+            u_int8_t  flags;
             u_int8_t  error;
         } PACKED writeres;
         struct {
@@ -127,9 +134,9 @@ int simc_cfgrd(u_int16_t bdf, u_int16_t addr, u_int8_t size, u_int64_t *val);
 int simc_cfgwr(u_int16_t bdf, u_int16_t addr, u_int8_t size, u_int64_t val);
 
 int simc_memrd(u_int16_t bdf, u_int8_t bar,
-               u_int64_t addr, u_int8_t size, u_int64_t *val);
+               u_int64_t addr, u_int8_t size, u_int8_t flags, u_int64_t *val);
 int simc_memwr(u_int16_t bdf, u_int8_t bar,
-               u_int64_t addr, u_int8_t size, u_int64_t val);
+               u_int64_t addr, u_int8_t size, u_int8_t flags, u_int64_t val);
 
 int simc_iord(u_int16_t bdf, u_int8_t bar,
               u_int16_t addr, u_int8_t size, u_int64_t *val);

--- a/hw/pci/pci.c
+++ b/hw/pci/pci.c
@@ -2948,7 +2948,7 @@ int pci_iommu_init_iotlb_notifier(PCIDevice *dev, IOMMUNotifier *n,
     PCIBus *iommu_bus;
     int devfn;
 
-    pci_device_get_iommu_bus_devfn(dev, &bus, &iommu_bus, &devfn);
+    pci_device_get_iommu_bus_devfn(dev, &iommu_bus, &bus, &devfn);
     if (iommu_bus && iommu_bus->iommu_ops->init_iotlb_notifier) {
         iommu_bus->iommu_ops->init_iotlb_notifier(bus, iommu_bus->iommu_opaque,
                                                   devfn, n, fn, opaque);
@@ -3006,7 +3006,7 @@ int pci_pri_request_page(PCIDevice *dev, uint32_t pasid, bool priv_req,
         return -EPERM;
     }
 
-    pci_device_get_iommu_bus_devfn(dev, &bus, &iommu_bus, &devfn);
+    pci_device_get_iommu_bus_devfn(dev, &iommu_bus, &bus, &devfn);
     if (iommu_bus && iommu_bus->iommu_ops->pri_request_page) {
         return iommu_bus->iommu_ops->pri_request_page(bus,
                                                      iommu_bus->iommu_opaque,
@@ -3030,7 +3030,7 @@ int pci_pri_register_notifier(PCIDevice *dev, uint32_t pasid,
         return -EPERM;
     }
 
-    pci_device_get_iommu_bus_devfn(dev, &bus, &iommu_bus, &devfn);
+    pci_device_get_iommu_bus_devfn(dev, &iommu_bus, &bus, &devfn);
     if (iommu_bus && iommu_bus->iommu_ops->pri_register_notifier) {
         iommu_bus->iommu_ops->pri_register_notifier(bus,
                                                     iommu_bus->iommu_opaque,
@@ -3047,7 +3047,7 @@ void pci_pri_unregister_notifier(PCIDevice *dev, uint32_t pasid)
     PCIBus *iommu_bus;
     int devfn;
 
-    pci_device_get_iommu_bus_devfn(dev, &bus, &iommu_bus, &devfn);
+    pci_device_get_iommu_bus_devfn(dev, &iommu_bus, &bus, &devfn);
     if (iommu_bus && iommu_bus->iommu_ops->pri_unregister_notifier) {
         iommu_bus->iommu_ops->pri_unregister_notifier(bus,
                                                       iommu_bus->iommu_opaque,
@@ -3079,7 +3079,7 @@ ssize_t pci_ats_request_translation(PCIDevice *dev, uint32_t pasid,
         return -EPERM;
     }
 
-    pci_device_get_iommu_bus_devfn(dev, &bus, &iommu_bus, &devfn);
+    pci_device_get_iommu_bus_devfn(dev, &iommu_bus, &bus, &devfn);
     if (iommu_bus && iommu_bus->iommu_ops->ats_request_translation) {
         return iommu_bus->iommu_ops->ats_request_translation(bus,
                                                      iommu_bus->iommu_opaque,
@@ -3103,7 +3103,7 @@ int pci_iommu_register_iotlb_notifier(PCIDevice *dev, uint32_t pasid,
         return -EPERM;
     }
 
-    pci_device_get_iommu_bus_devfn(dev, &bus, &iommu_bus, &devfn);
+    pci_device_get_iommu_bus_devfn(dev, &iommu_bus, &bus, &devfn);
     if (iommu_bus && iommu_bus->iommu_ops->register_iotlb_notifier) {
         iommu_bus->iommu_ops->register_iotlb_notifier(bus,
                                            iommu_bus->iommu_opaque, devfn,
@@ -3125,7 +3125,7 @@ int pci_iommu_unregister_iotlb_notifier(PCIDevice *dev, uint32_t pasid,
         return -EPERM;
     }
 
-    pci_device_get_iommu_bus_devfn(dev, &bus, &iommu_bus, &devfn);
+    pci_device_get_iommu_bus_devfn(dev, &iommu_bus, &bus, &devfn);
     if (iommu_bus && iommu_bus->iommu_ops->unregister_iotlb_notifier) {
         iommu_bus->iommu_ops->unregister_iotlb_notifier(bus,
                                                         iommu_bus->iommu_opaque,
@@ -3139,11 +3139,9 @@ int pci_iommu_unregister_iotlb_notifier(PCIDevice *dev, uint32_t pasid,
 int pci_iommu_get_iotlb_info(PCIDevice *dev, uint8_t *addr_width,
                              uint32_t *min_page_size)
 {
-    PCIBus *bus;
     PCIBus *iommu_bus;
-    int devfn;
 
-    pci_device_get_iommu_bus_devfn(dev, &bus, &iommu_bus, &devfn);
+    pci_device_get_iommu_bus_devfn(dev, &iommu_bus, NULL, NULL);
     if (iommu_bus && iommu_bus->iommu_ops->get_iotlb_info) {
         iommu_bus->iommu_ops->get_iotlb_info(iommu_bus->iommu_opaque,
                                              addr_width, min_page_size);


### PR DESCRIPTION
Also improve VSW-286 fix.
The change will require a corresponding update in sw when pulled.