### PR TITLE
Fix build when riscv option is not the last one.

### DIFF
--- a/util/meson.build
+++ b/util/meson.build
@@ -138,9 +138,8 @@ elif cpu == 's390x'
   util_ss.add(files('s390x_pci_mmio.c'))
 endif
 
-# Meson forces us to pass the dependency this way: if CONFIG_VUL_MODEL is not defined, it'll still try to check for
-# libzmq availabilty and this is not ok
-if config_target.get('CONFIG_VUL_MODEL', 'n') == 'y'
-  util_ss.add(files('vul_zmq.c'))
-  util_ss.add(dependency('libzmq'))
+# Meson forces us to pass the dependency this way: if CONFIG_VUL_MODEL is not defined, it will still try to check for
+# libzmq availability and this is not ok.
+if config_all_devices.has_key('CONFIG_VUL_MODEL')
+  specific_ss.add(when: 'CONFIG_VUL_MODEL', if_true: [files('vul_zmq.c'), dependency('libzmq')])
 endif


### PR DESCRIPTION
When using util_ss.add(dependency('libzmq')) it adds it to all targets after riscv, so it only worked when riscv was the last.