### PR TITLE
VSW-2272: modacc: allow large MEM_RST sizes

### DIFF
--- a/hw/misc/modacc.c
+++ b/hw/misc/modacc.c
@@ -124,9 +124,14 @@ static void copy_data_from_mem(ModAccState *s)
 
 static void perform_op(ModAccState *s)
 {
-    assert(s->regs.size <= s->region_size - sizeof(s->regs));
-
     enum ctrl_opcode opcode = (s->regs.ctrl & CTRL_OPCODE_MASK) >> CTRL_OPCODE_LSB;
+
+    /* MEM_RST and DB do not transfer through the data buffer, so they
+     * are not bounded by region_size. Other opcodes use the buffer and
+     * must fit. */
+    if (opcode != CTRL_OPCODE_MEM_RST && opcode != CTRL_OPCODE_DB) {
+        assert(s->regs.size <= s->region_size - sizeof(s->regs));
+    }
 
     uint64_t addr = (uint64_t)s->regs.hi_addr << 32 | (uint64_t)s->regs.lo_addr;
 

--- a/util/vul_zmq.c
+++ b/util/vul_zmq.c
@@ -345,7 +345,11 @@ static void rst_mem(uint64_t addr, uint32_t size)
     }
 }
 
-#define RST_CHUNK_SIZE 0x40000
+/* MEM_RESET is a metadata-only ZMQ message (no payload), so the chunk
+ * size only bounds how much work the server does between replies, not
+ * the wire size. Use a large chunk so a typical multi-MB qstate / table
+ * zero turns into a single round-trip. */
+#define RST_CHUNK_SIZE 0x4000000  /* 64 MiB */
 void vul_zmq_rst_mem(uint64_t addr, uint32_t size)
 {
     do {


### PR DESCRIPTION
This is the first in a series of patches by Claude+Opus to reduce the time it takes firmware to boot on the model.  There are several dependency chains in the patches, so I'm going to dribble them gradually into PRs.  The boot time reduced from ~30 s to ~13 s in total at the point at which I told it to hold fire while I got stuff merged.

----

Companion to the forthcoming firmware-side change "VSW-2272: modacc: don't chunk MEM_RST by max_buf_size" in the ainic-rtos repo.

Two changes to QEMU's modacc model so that the firmware can pass a multi-MB MEM_RST size in one go:

  - hw/misc/modacc.c perform_op(): the assertion size <= region_size - sizeof(regs) bounds the SIZE register against the device's data-buffer area. That's correct for opcodes that copy through the buffer (MEM_RD, MEM_WR, CSR_RD, CSR_WR), but MEM_RST and DB carry no payload through the buffer at all, so the assertion shouldn't fire for them. Skip it for those two opcodes.

  - util/vul_zmq.c vul_zmq_rst_mem(): MEM_RESET is a metadata-only ZMQ message (header + addr + size, no payload), so the chunk size only bounds how much work the model server does between replies. Bump RST_CHUNK_SIZE from 256 KiB to 64 MiB so the typical multi-MB qstate / scheduler-table zero turns into one ZMQ round-trip instead of several.

Without this, the firmware modacc-driver fix ("don't chunk MEM_RST") would trip the perform_op assertion on the first multi-MB call, and the firmware-side wins from larger MEM_RST batches would be limited by the QEMU re-chunking. The biggest effect is on the pciehw_memset() fix in the ainic-rtos submodule, which collapses a ~5 s pcie_hwmem zero into ~57 ms on the rdma_pulsar sw_emu boot. Without this QEMU change in place, that firmware fix would crash the QEMU model on the first call.

----

#### Testing done

Claude was running a DOL on each change that it made.  I hadn't particularly asked it to look at qemu, but it found it and figured out how to rebuild it as it iterated.

----

I don't have write permissions on this repo, so some pings for review: @lizzi-xlnx @idruzhinin @drussell-xilinx @andriuss-amd @rhughes-xilinx @matthewu-xilinx @smchale-xilinx.