### PR TITLE
Give qemu threads an explicit 8MiB stack size

### DIFF
--- a/util/qemu-thread-posix.c
+++ b/util/qemu-thread-posix.c
@@ -412,6 +412,8 @@ void qemu_thread_create(QemuThread *thread, const char *name,
         error_exit(err, __func__);
     }
 
+    pthread_attr_setstacksize(&attr, 8 * 1024 * 1024);
+
     if (mode == QEMU_THREAD_DETACHED) {
         pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
     }


### PR DESCRIPTION
musl's default pthread stack size (128KiB) is far smaller than glibc's and can cause crashes in our QEMU.