### PR TITLE
Increase stack size to 8 MiB.

### DIFF
--- a/scripts/static-build/build.sh
+++ b/scripts/static-build/build.sh
@@ -51,7 +51,8 @@ cd "$REPO_ROOT"
             --enable-linux-aio \
             --enable-attr \
             --disable-docs \
-            --extra-cflags=-Wno-error=discarded-qualifiers
+            --extra-cflags=-Wno-error=discarded-qualifiers \
+            --extra-ldflags=-Wl,-z,stack-size=8388608
         ninja -j\$(nproc)
     "
 


### PR DESCRIPTION
Default stack size in musl is 128 KiB
QEMU occasionally needs more than that and causes stack overflow.

Increase it to the same amount glibc allocates.

https://wiki.musl-libc.org/functional-differences-from-glibc.html#Thread-stack-size